### PR TITLE
Maven Central Publishing config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,12 @@
-organization := "keen"
-
 name := "keenclient-scala"
 
-version := "1.0.4-SNAPSHOT"
+organization := "io.keen"
+
+description := "Keen IO SDK/client library for Scala"
+
+homepage := Some(url("https://github.com/keenlabs/KeenClient-Scala"))
+
+version := "0.4.0-SNAPSHOT"
 
 scalaVersion := "2.11.2"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,4 @@
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+

--- a/publishing.sbt
+++ b/publishing.sbt
@@ -1,0 +1,45 @@
+/*
+ * Maven Central Publishing - Sonatype OSSRH
+ *
+ * For reference, see:
+ *   http://www.scala-sbt.org/0.13/docs/Publishing.html
+ *   http://www.scala-sbt.org/0.13/docs/Using-Sonatype.html
+ */
+import SonatypeKeys._
+
+sonatypeSettings
+
+credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+
+organizationName := "Keen IO"
+organizationHomepage := Some(url("https://keen.io/"))
+
+publishMavenStyle := true
+publishArtifact in Test := false
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+}
+
+licenses := Seq("MIT License" -> url("http://www.opensource.org/licenses/mit-license.php"))
+
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/keenlabs/KeenClient-Scala"),
+    "scm:git:https://github.com/keenlabs/KeenClient-Scala.git",
+    Some("scm:git:git@github.com:keenlabs/KeenClient-Scala.git")
+  )
+)
+
+// Central doesn't allow any external repository sources.
+pomIncludeRepository := { _ => false }
+pomExtra :=
+  <developers>
+    <id>keenlabs</id>
+    <name>Keen IO</name>
+    <email></email>
+  </developers>
+


### PR DESCRIPTION
I haven't actually verified that this works since of course I don't have your Sonatype credentials, but I thought I'd help get the ball rolling. I emulated [the metadata from KeenClient-Java](https://github.com/keenlabs/KeenClient-Java/blob/master/gradle.properties) so I believe things are mostly correct here. A few things to note though:
- License is set as Apache 2 because that's what KeenClient-Java is using, but #22 is for MIT, so need to settle that matter.
- It'd be nice if we could reset the version number to sub-1.0 before beginning to publish artifacts—the `README` warns that the API is still in flux, and I think we shouldn't commit to SemVer backwards compatibility promises yet (#20 and some follow-up I have in the works being a few reasons :smile:). Since users haven't been able to install published artifacts before I'm guessing this wouldn't upset anyone too much—switching from an unmanaged dependency to adding a new managed one to build config will be a conscious decision where people ought to be reasonably expected to check changelogs.

For reference, to test/use this, make sure you set Keen's Sonatype credentials in `~/.ivy2/.credentials` [as described here](http://www.scala-sbt.org/0.13/docs/Publishing.html#Credentials) and that you have a published PGP key for signing [as described here](http://www.scala-sbt.org/0.13/docs/Using-Sonatype.html), then in theory `sbt publishSigned` should work. It's okay to run a test as it's only the first staging step of [the two-part public release process](http://central.sonatype.org/pages/releasing-the-deployment.html).
