### PR TITLE
Typesafe Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ target
 tmp
 .idea/
 .idea_modules/
+
+# You can change settings here for working on the library in development
+src/main/resources/application.conf
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.5.0-SNAPSHOT
+
+* Configuration with Typesafe Config - #25 (ches)
+
 ## v0.4.0 - Jan 3rd, 2015
 
 * Began CHANGELOG

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@
   * Added HTTP adapter for [Dispatch] as alternative to Spray
 * [Ches Martin](https://github.com/ches)
   * Created the `AccessLevel` traits abstraction
+  * Added Typesafe Config support for settings
 
 
 [Dispatch]: http://dispatch.databinder.net/

--- a/README.md
+++ b/README.md
@@ -13,21 +13,10 @@ Additional API features will be added over time. Contributions are welcome!
 ## Use It - A Quick Taste
 
 ```scala
-import io.keen.client.scala.{ Client, Reader, Writer }
+import io.keen.client.scala.{ Client, Writer }
 
-// You probably have some form of configuration object in your app already,
-// this is just an example.
-object KeenSettings {
-  val projectId = sys.env("KEEN_PROJECT_ID")
-  val readKey = sys.env("KEEN_READ_KEY")
-  val writeKey = sys.env("KEEN_WRITE_KEY")
-}
-
-// Construct a client with read and write access, providing the required keys.
-val keen = new Client(KeenSettings.projectId) with Reader with Writer {
-  override val readKey = KeenSettings.readKey
-  override val writeKey = KeenSettings.writeKey
-}
+// Assumes you've configured a write key as explained in Configuration below
+val keen = new Client with Writer
 
 // Publish an event!
 keen.addEvent(
@@ -76,11 +65,38 @@ security model][security]. These are represented by Scala traits called
 `Reader`, `Writer`, and `Master`. According to the level of access that your
 application requires, you must mix the appropriate trait(s) into your client
 instance when creating it, and configure your corresponding API keys. This is
-demonstrated in the example below.
+demonstrated in the examples.
 
-Our recommended means of providing settings is through environment variables, to
-avoid storing credentials in source control. We intend to support a config file
-soon, but would still discourage you from using that for credentials.
+Configuration is supported by the [Typesafe config] library, offering all the
+flexibility you could wish to provide settings through a file, environment
+variables, or programmatically. We recommend environment variables for your API
+keys at very least, to avoid storing credentials in source control. To that end,
+the following will be honored by default if set:
+
+* `KEEN_PROJECT_ID`
+* `KEEN_READ_KEY`
+* `KEEN_WRITE_KEY`
+* `KEEN_MASTER_KEY`
+
+To configure with a file, it must be on the classpath, customarily called
+`application.conf` though you may use others--see the Typesafe config
+documentation for all the options and details of the file format. [Our
+`reference.conf`] reflects all of the settings you can configure and their
+default values.
+
+For advanced needs, you may provide your own custom [`Config`] object by simply
+passing it to the client constructor:
+
+```scala
+import io.keen.client.scala.Client
+
+val keen = new Client(config = myCustomConfigObject)
+```
+
+When using environment variables, you might like [sbt-dotenv] in your
+development setup (install it as a [global plugin], and `chmod 600` your `.env`
+files that contain credentials!). In production, a [good service manager][runit]
+can set env vars for app processes with ease. On Heroku you'll be right at home.
 
 ## Dependencies
 
@@ -147,4 +163,10 @@ Unit tests can be run with the standard SBT `test`, `testQuick`, etc.
 [Dispatch]: http://dispatch.databinder.net/
 [grizzled-slf4j]: http://software.clapper.org/grizzled-slf4j/
 [security]: https://keen.io/docs/security/
+[Typesafe config]: https://github.com/typesafehub/config
+[Our `reference.conf`]: https://github.com/keenlabs/KeenClient-Scala/tree/master/src/main/resources/reference.conf
+[`Config`]: http://typesafehub.github.io/config/latest/api/com/typesafe/config/Config.html
+[sbt-dotenv]: https://github.com/mefellows/sbt-dotenv
+[global plugin]: http://www.scala-sbt.org/0.13/docs/Global-Settings.html
+[runit]: http://smarden.org/runit/
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ libraryDependencies ++= {
   val sprayVersion = "1.3.2"
   Seq(
     "com.typesafe.akka"        %% "akka-actor"      % "2.3.6",
+    "com.typesafe"             %  "config"          % "1.2.1",
     "io.spray"                 %% "spray-can"       % sprayVersion,
     "io.spray"                 %% "spray-http"      % sprayVersion,
     "io.spray"                 %% "spray-httpx"     % sprayVersion,

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,11 @@
+keen {
+  project-id = ${KEEN_PROJECT_ID}
+
+  # All config keys MUST be set, except those in this group.
+  optional {
+    master-key = ${KEEN_MASTER_KEY}
+    read-key = ${KEEN_READ_KEY}
+    write-key = ${KEEN_WRITE_KEY}
+  }
+}
+

--- a/src/main/scala/io/keen/client/scala/Client.scala
+++ b/src/main/scala/io/keen/client/scala/Client.scala
@@ -23,8 +23,8 @@ class Client(
    * Disconnects any remaining connections. Both idle and active. If you are accessing
    * Keen through a proxy that keeps connections alive this is useful.
    */
-  def shutdown {
-    httpAdapter.shutdown
+  def shutdown() = {
+    httpAdapter.shutdown()
   }
 }
 

--- a/src/main/scala/io/keen/client/scala/HttpAdapter.scala
+++ b/src/main/scala/io/keen/client/scala/HttpAdapter.scala
@@ -19,5 +19,5 @@ trait HttpAdapter {
     params: Map[String, Option[String]] = Map.empty
   ): Future[Response]
 
-  def shutdown: Unit
+  def shutdown(): Unit
 }

--- a/src/main/scala/io/keen/client/scala/HttpAdapterDispatch.scala
+++ b/src/main/scala/io/keen/client/scala/HttpAdapterDispatch.scala
@@ -52,7 +52,7 @@ class HttpAdapterDispatch(httpTimeoutSeconds: Int = 10) extends HttpAdapter {
     result map (r => Response(r.getStatusCode, r.getResponseBody))
   }
 
-  def shutdown = http.shutdown
+  def shutdown() = http.shutdown()
 
-  override protected def finalize = shutdown
+  override protected def finalize() = shutdown()
 }

--- a/src/main/scala/io/keen/client/scala/HttpAdapterSpray.scala
+++ b/src/main/scala/io/keen/client/scala/HttpAdapterSpray.scala
@@ -72,7 +72,7 @@ class HttpAdapterSpray(httpTimeoutSeconds: Int = 10)(implicit val actorSystem: A
       })
   }
 
-  def shutdown = {
+  def shutdown() = {
     (IO(Http) ? Http.CloseAll) onComplete {
       // When this completes we will shutdown the actor system if it wasn't
       // supplied by the user.

--- a/src/main/scala/io/keen/client/scala/Settings.scala
+++ b/src/main/scala/io/keen/client/scala/Settings.scala
@@ -1,0 +1,34 @@
+package io.keen.client.scala
+
+import com.typesafe.config._
+
+/**
+ * Configuration settings for Keen Client.
+ *
+ * At construction the given `Config` parsed from config files, properties, etc.
+ * is validated to ensure that all required keys are present.
+ *
+ * @constructor Creates a new Settings instance.
+ *
+ * @param config A Typesafe `Config` instance containing at least the required
+ *   settings under the "keen" path reflected in the reference file.
+ *
+ * @throws ConfigException.Missing if required configuration keys are not provided.
+ * @throws ConfigException.WrongType if a given configuration value is not of
+ *   the required or sensibly coercible type.
+ *
+ * @todo A helpful toString could be useful here, but should maybe sanitize keys
+ *   from accidental logging through exceptions reports, etc.?
+ */
+class Settings(config: Config) {
+  // Fail fast if any required settings are missing.
+  private val validationReference = ConfigFactory.defaultReference.withoutPath("keen.optional")
+  config.checkValid(validationReference, "keen")
+
+  val projectId: String = config.getString("keen.project-id")
+
+  val masterKey: Option[String] = config.getOptionalString("keen.optional.master-key")
+  val readKey: Option[String]   = config.getOptionalString("keen.optional.read-key")
+  val writeKey: Option[String]  = config.getOptionalString("keen.optional.write-key")
+}
+

--- a/src/main/scala/io/keen/client/scala/package.scala
+++ b/src/main/scala/io/keen/client/scala/package.scala
@@ -1,0 +1,21 @@
+package io.keen.client
+
+import com.typesafe.config.{ Config, ConfigFactory }
+
+package object scala {
+  /**
+   * Enrichment for Typesafe Config to wrap some optional settings in Option.
+   *
+   * @internal Could use [[https://github.com/ceedubs/ficus Ficus]] for fancy
+   * stuff, but for simple Options for now this is lighter.
+   */
+  implicit class RichConfig(val self: Config) extends AnyVal {
+    def getOptionalString(path: String): Option[String] = {
+      if (self.hasPath(path)) Some(self.getString(path))
+      else None
+    }
+  }
+
+  case class MissingCredential(cause: String) extends RuntimeException(cause)
+}
+

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -2,10 +2,12 @@ akka {
   log-dead-letters = off
   log-dead-letters-during-shutdown = off
 }
+
 spray.can {
   client {
-  	parsing {
-  		illegal-header-warnings = off
-  	}
+    parsing {
+      illegal-header-warnings = off
+    }
   }
 }
+

--- a/src/test/scala/ClientIntegrationSpec.scala
+++ b/src/test/scala/ClientIntegrationSpec.scala
@@ -18,19 +18,13 @@ class ClientIntegrationSpec extends Specification with NoTimeConversions {
 
   sequential
 
+  // This set of expectations currently assumes master access. Should
+  // eventually break out some to test access control granularly.
   "Client" should {
 
-    val projectId = sys.env("KEEN_PROJECT_ID")
+    lazy val client = new Client with Master
 
-    // This set of expectations currently assumes master access. Should
-    // eventually break out some to test access control granularly.
-    trait Keys {
-      val masterKey = sys.env("KEEN_MASTER_KEY")
-    }
-
-    lazy val client = new Client(projectId = projectId) with Master with Keys
-
-    lazy val dispatchClient = new Client(projectId = projectId) with Master with Keys {
+    lazy val dispatchClient = new Client with Master {
       override val httpAdapter = new HttpAdapterDispatch
     }
 

--- a/src/test/scala/ClientIntegrationSpec.scala
+++ b/src/test/scala/ClientIntegrationSpec.scala
@@ -172,7 +172,7 @@ class ClientIntegrationSpec extends Specification with NoTimeConversions {
     }
 
     "shutdown" in {
-      client.shutdown
+      client.shutdown()
       1 must beEqualTo(1)
     }
   } section("integration")

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -60,7 +60,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
     def getUrl = lastUrl
 
-    def shutdown = {}
+    def shutdown() = {}
   }
 
   class FiveHundredHttpAdapter extends HttpAdapterSpray {
@@ -210,7 +210,7 @@ class ClientSpec extends Specification with NoTimeConversions {
     }
 
     "shutdown" in {
-      client.shutdown
+      client.shutdown()
       1 must beEqualTo(1)
     }
   }
@@ -262,7 +262,7 @@ class ClientSpec extends Specification with NoTimeConversions {
       adapter.actorSystem must be(externalSystem)
 
       // We don't terminate a user-supplied actor system
-      client.shutdown
+      client.shutdown()
       externalSystem.awaitTermination(timeout) must throwA[TimeoutException]
       externalSystem.isTerminated must beFalse
     }
@@ -275,7 +275,7 @@ class ClientSpec extends Specification with NoTimeConversions {
       // TODO: httpAdapter field should be private
       client.httpAdapter.actorSystem must be(externalSystem)
 
-      client.shutdown
+      client.shutdown()
       externalSystem.awaitTermination(timeout) must throwA[TimeoutException]
       externalSystem.isTerminated must beFalse
     }

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -1,5 +1,6 @@
 package test
 
+import scala.collection.JavaConversions._
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ Await, Future, TimeoutException }
@@ -94,6 +95,16 @@ class ClientSpec extends Specification with NoTimeConversions {
     }
   }
 
+  val dummyConfig = ConfigFactory.parseMap(
+    Map(
+      "keen.project-id" -> "abc",
+      "keen.optional.master-key" -> "masterKey",
+      "keen.optional.read-key" -> "readKey",
+      "keen.optional.write-key" -> "writeKey"
+    )
+  )
+
+
   // Sequential because it's less work to share the client instance
   // TODO: set up separate read-only client, writer client, etc. instead of
   // doing everything in this suite with a master key.
@@ -101,8 +112,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
   "Client" should {
 
-    val client = new Client(projectId = "abc") with Master {
-      override val masterKey = "masterKey"
+    val client = new Client(config = dummyConfig) with Master {
       override val httpAdapter = new OkHttpAdapter
     }
 
@@ -205,12 +215,48 @@ class ClientSpec extends Specification with NoTimeConversions {
     }
   }
 
+  "Client with Reader" >> {
+    class ReadClient(config: Config) extends Client(config) with Reader
+
+    "without a read key configured" >> {
+      val badConfig = dummyConfig.withoutPath("keen.optional.read-key")
+
+      "throws MissingCredential on construction" in {
+        new ReadClient(config = badConfig) must throwA[MissingCredential]
+      }
+    }
+  }
+
+  "Client with Writer" >> {
+    class WriteClient(config: Config) extends Client(config) with Writer
+
+    "without a write key configured" >> {
+      val badConfig = dummyConfig.withoutPath("keen.optional.write-key")
+
+      "throws MissingCredential on construction" in {
+        new WriteClient(config = badConfig) must throwA[MissingCredential]
+      }
+    }
+  }
+
+  "Client with Master" >> {
+    class MasterClient(config: Config) extends Client(config) with Master
+
+    "without a master key configured" >> {
+      val badConfig = dummyConfig.withoutPath("keen.optional.master-key")
+
+      "throws MissingCredential on construction" in {
+        new MasterClient(config = badConfig) must throwA[MissingCredential]
+      }
+    }
+  }
+
   "Client with Spray HttpAdapter" should {
     lazy val externalSystem = ActorSystem("keen-test-user-supplied")
 
     "use explicit user-supplied actor system" in {
       val adapter = new HttpAdapterSpray()(externalSystem)
-      val client = new Client(projectId = "abc") {
+      val client = new Client(config = dummyConfig) {
         override val httpAdapter = adapter
       }
       adapter.actorSystem must be(externalSystem)
@@ -223,7 +269,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
     "use implicit user-supplied actor system" in {
       implicit val system = externalSystem
-      val client = new Client(projectId = "abc") {
+      val client = new Client(config = dummyConfig) {
         override val httpAdapter = new HttpAdapterSpray
       }
       // TODO: httpAdapter field should be private
@@ -241,8 +287,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
   "Client 500 failures" should {
 
-    val client = new Client(projectId = "abc") with Master {
-      override val masterKey = "masterKey"
+    val client = new Client(config = dummyConfig) with Master {
       override val httpAdapter = new FiveHundredHttpAdapter()
     }
 
@@ -255,8 +300,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
   "Client future failures" should {
 
-    val client = new Client(projectId = "abc") with Master {
-      override val masterKey = "masterKey"
+    val client = new Client(config = dummyConfig) with Master {
       override val httpAdapter = new SlowHttpAdapter
     }
 
@@ -269,7 +313,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
     "handle dispatch without an actor system" in {
       val attempt = Try({
-        val client = new Client(projectId = "abc") {
+        val client = new Client(config = dummyConfig) {
           override val httpAdapter = new HttpAdapterDispatch
         }
       })
@@ -277,3 +321,4 @@ class ClientSpec extends Specification with NoTimeConversions {
     }
   }
 }
+


### PR DESCRIPTION
As discussed some back on #20, this integrates Typesafe Config for configuration settings. This allows very flexible means of providing configuration: config files, environment variables, and programmatic.

At this point it's only for the API keys, for which I agree it's best to encourage use of environment variables so credentials aren't kept in source control, but ops teams will have their own preferences. Writing credentials to a config file in production through reasonably secured means like Chef Vault/encrypted data bags might be acceptable too, etc. Also, I'd like to make some additional things that aren't sensitive configurable too, like values for timeouts, and a file may be more convenient for these, particularly if you're already using Typesafe Config for other stuff like Akka or your own app itself.

I'm doing some further work to move other things into config that I previously marked as TODO, like the API endpoint/port, but that is turning into a broader-reaching refactoring of the `HttpAdapter` trait interface, so I felt like this was currently enough to review as-is and is more immediately useful to users than refactoring that is mostly internal.

Also as noted on #20 this returns client instantiation to something simpler-looking in the normal case (meaning users have keys configured in either file or environment)—instead of 

```scala
val keen = new Client("projectID") with Reader with Writer {
  val readKey = "myReadKey"
  val writeKey = "myWriteKey"
}
```

for typical cases it is now:

```scala
val keen = new Client with Reader with Writer
```

This still fails fast and loudly if a needed key is not configured.