### PR TITLE
Env vars are optional fallbacks for config

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,11 +1,11 @@
 keen {
-  project-id = ${KEEN_PROJECT_ID}
+  project-id = ${?KEEN_PROJECT_ID}
 
   # All config keys MUST be set, except those in this group.
   optional {
-    master-key = ${KEEN_MASTER_KEY}
-    read-key = ${KEEN_READ_KEY}
-    write-key = ${KEEN_WRITE_KEY}
+    master-key = ${?KEEN_MASTER_KEY}
+    read-key = ${?KEEN_READ_KEY}
+    write-key = ${?KEEN_WRITE_KEY}
   }
 }
 


### PR DESCRIPTION
Following #25: not having an env var set won’t error the unit tests that explicitly set config by other means. This still fails as desired when a user completely forgets a necessary setting.