### PR TITLE
Add scoped key operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ val keen = new Client {
 }
 ```
 
+### Scoped Keys
+
+`io.keen.client.scala.util.ScopedKeys` has a `encrypt` and `decrypt` method for handling
+[Scoped Keys](https://keen.io/docs/security/#scoped-key). If you have trouble with Java Exceptions see
+[this StackOverflow answer](http://stackoverflow.com/questions/6481627/java-security-illegal-key-size-or-default-parameters).
+
 ### JSON
 
 Presently this library does **not** do any JSON parsing. It works with strings only. It is

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ libraryDependencies ++= {
     "io.spray"                 %% "spray-util"      % sprayVersion,
     "net.databinder.dispatch"  %% "dispatch-core"   % "0.11.2",
     "org.clapper"              %% "grizzled-slf4j"  % "1.0.2",
+    "commons-codec"             % "commons-codec"   % "1.10",
     "org.specs2"               %% "specs2"          % "2.4.13"       % "it,test",
     "org.slf4j"                %  "slf4j-simple"    % "1.7.6"        % "it,test"
   )

--- a/src/main/scala/io/keen/client/scala/util/ScopedKeys.scala
+++ b/src/main/scala/io/keen/client/scala/util/ScopedKeys.scala
@@ -1,0 +1,44 @@
+package io.keen.client.scala.util
+
+import javax.crypto.Cipher
+import javax.crypto.spec._
+
+import org.apache.commons.codec.binary.Hex
+
+object ScopedKeys {
+
+  val BLOCK_SIZE = 32
+
+  def decrypt(apiKey: String, scopedKey: String) = {
+
+    val hexedIv = scopedKey.substring(0, 32)
+    val hexedCipherText = scopedKey.substring(32)
+
+    val iv = Hex.decodeHex(hexedIv.toCharArray)
+    val cipherText = Hex.decodeHex(hexedCipherText.toCharArray)
+
+    val secret = new SecretKeySpec(padApiKey(apiKey), "AES")
+
+    val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+
+    val ivParameterSpec = new IvParameterSpec(iv);
+    cipher.init(Cipher.DECRYPT_MODE, secret, ivParameterSpec);
+
+    // do the decryption
+    new String(cipher.doFinal(cipherText), "UTF-8");
+  }
+
+  def encrypt(apiKey: String, options: String) = {
+    val secret = new SecretKeySpec(padApiKey(apiKey), "AES")
+
+    val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+    cipher.init(Cipher.ENCRYPT_MODE, secret)
+
+    val iv = cipher.getParameters.getParameterSpec(classOf[IvParameterSpec]).getIV
+    val cipherText = cipher.doFinal(options.getBytes("UTF-8"))
+
+    Hex.encodeHexString(iv) + Hex.encodeHexString(cipherText)
+  }
+
+  private def padApiKey(key: String) = key.padTo(BLOCK_SIZE, " ").mkString.getBytes("UTF-8")
+}

--- a/src/test/scala/ScopedKeySpec.scala
+++ b/src/test/scala/ScopedKeySpec.scala
@@ -1,0 +1,28 @@
+package test
+
+import org.specs2.mutable.Specification
+
+import io.keen.client.scala.util.ScopedKeys
+
+class ScopedKeySpec extends Specification {
+
+  val apiKey = "80ce00d60d6443118017340c42d1cfaf"
+
+  "Scoped Keys should" should {
+
+    "handle encryption and decryption" in {
+
+      val options = """{
+    "filters": [{
+        "property_name": "account_id",
+        "operator": "eq",
+        "property_value": 123
+    }],
+    "allowed_operations": [ "read" ]
+}"""
+
+      val enciphered = ScopedKeys.encrypt(apiKey, options)
+      options must beEqualTo(ScopedKeys.decrypt(apiKey, enciphered))
+    }
+  }
+}


### PR DESCRIPTION
# What's This PR Do?

Adds [scoped key](https://keen.io/docs/security/#scoped-key) operations to the SDK.

# Motivation

I needed this to do some testing and I prefer to use Scala, so this was convenient.

# Notes

* I basically just lifted out [the Java SDK's code for this](https://github.com/keenlabs/KeenClient-Java/blob/master/core/src/main/java/io/keen/client/java/ScopedKeys.java).
* I added a note about this to the README, since you need to get the policy files for encryption to use it.

# Testing

Added tests!