### PR TITLE
Add scoped key functionality to KeenClient-Scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ resp map { println("I succeeded!") } getOrElse { println("I failed :(") }
 val masterKeen = new Client with Master
 
 val scopedKey = masterKeen.getScopedKey(List("read"))
-val narrowerScopedKey = masterKeen.getScopedKey(List("read"), Some("""[{
+val narrowerScopedKey = masterKeen.getScopedKey(List("read"), Some(Seq("""{
     "property_name": "user_id",
     "operator": "eq",
     "property_value": 123
-}]"""))
+}""")))
 ```
 
 ## Get It

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ resp onComplete {
 // Or using map
 resp map { println("I succeeded!") } getOrElse { println("I failed :(") }
 
-// You can even generate a scoped key!
+// You can generate scoped keys using a client ...
 val masterKeen = new Client with Master
 
 val scopedKey = masterKeen.getScopedKey(List("read"))
@@ -52,6 +52,16 @@ val narrowerScopedKey = masterKeen.getScopedKey(List("read"), Some(Seq("""{
     "operator": "eq",
     "property_value": 123
 }""")))
+
+// ... or do the same thing with the scoped key interface directly
+import io.keen.client.scala.util.ScopedKeys
+
+val apiKey = "my api key exactly 32 chars long"
+val clearText = """{"allowed_operations": ["write"]}"""
+val cipherText = scopedKey.encrypt(apiKey, clearText)
+
+// and if you feel like it:
+val clearTextAgain = scopedKey.decrypt(apiKey, cipherText)
 ```
 
 ## Get It
@@ -146,8 +156,10 @@ val keen = new Client {
 
 ### Scoped Keys
 
-`io.keen.client.scala.util.ScopedKeys` has a `encrypt` and `decrypt` method for handling
-[Scoped Keys](https://keen.io/docs/security/#scoped-key). If you have trouble with Java Exceptions see
+Instances of `Client with Master` have a `createScopedKey` method for creating
+[scoped keys](https://keen.io/docs/security/#scoped-key), which is a thin
+wrapper around the encrypt method in `io.keen.client.scala.util.ScopedKeys`.
+If you have trouble with Java Exceptions see
 [this StackOverflow answer](http://stackoverflow.com/questions/6481627/java-security-illegal-key-size-or-default-parameters).
 
 ### JSON

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ resp onComplete {
 
 // Or using map
 resp map { println("I succeeded!") } getOrElse { println("I failed :(") }
+
+// You can even generate a scoped key!
+val masterKeen = new Client with Master
+
+val scopedKey = masterKeen.getScopedKey(List("read"))
+val narrowerScopedKey = masterKeen.getScopedKey(List("read"), Some("""[{
+    "property_name": "user_id",
+    "operator": "eq",
+    "property_value": 123
+}]"""))
 ```
 
 ## Get It
@@ -174,4 +184,3 @@ that you didn't expect!**
 [sbt-dotenv]: https://github.com/mefellows/sbt-dotenv
 [global plugin]: http://www.scala-sbt.org/0.13/docs/Global-Settings.html
 [runit]: http://smarden.org/runit/
-

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Additional API features will be added over time. Contributions are welcome!
 ## Use It - A Quick Taste
 
 ```scala
-import io.keen.client.scala.{ Client, Writer }
+import io.keen.client.scala.{ Client, Master, Writer }
 
 // Assumes you've configured a write key as explained in Configuration below
 val keen = new Client with Writer

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,6 @@ libraryDependencies ++= {
     "io.spray"                 %% "spray-util"      % sprayVersion,
     "net.databinder.dispatch"  %% "dispatch-core"   % "0.11.2",
     "org.clapper"              %% "grizzled-slf4j"  % "1.0.2",
-    "commons-codec"             % "commons-codec"   % "1.10",
     "org.specs2"               %% "specs2"          % "2.4.13"       % "it,test",
     "org.slf4j"                %  "slf4j-simple"    % "1.7.6"        % "it,test"
   )

--- a/src/main/scala/io/keen/client/scala/Client.scala
+++ b/src/main/scala/io/keen/client/scala/Client.scala
@@ -429,9 +429,9 @@ trait Master extends Reader with Writer {
    * @param allowedOperations The allowed operations ("read", "write", or both)
    * @param filters The filters that restrict any queries executed with this key
    */
-  def createScopedKey(allowedOperations: Seq[String], filters: Option[String]=None) {
+  def createScopedKey(allowedOperations: Seq[String], maybeFilters: Option[Seq[String]]=None): String = {
     val allowedOperationsList = allowedOperations.map({op => s""""${op}""""}).mkString(",")
-    val filtersString = filters.map({ filter => s""", "filters": [${filter}]""" }).getOrElse("")
+    val filtersString = maybeFilters.map({ filters => s""", "filters": [${filters.mkString(",")}]""" }).getOrElse("")
     val masterKeyBytes: Array[Byte] = masterKey.getBytes("UTF-8") //parseHexBinary(masterKey)
     val cipher: Cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
     val secretKey: SecretKeySpec = new SecretKeySpec(masterKeyBytes, "AES")

--- a/src/main/scala/io/keen/client/scala/Client.scala
+++ b/src/main/scala/io/keen/client/scala/Client.scala
@@ -432,9 +432,8 @@ trait Master extends Reader with Writer {
   def createScopedKey(allowedOperations: Seq[String], maybeFilters: Option[Seq[String]]=None): String = {
     val allowedOperationsList = allowedOperations.map({op => s""""${op}""""}).mkString(",")
     val filtersString = maybeFilters.map({ filters => s""", "filters": [${filters.mkString(",")}]""" }).getOrElse("")
-    val masterKeyBytes: Array[Byte] = masterKey.getBytes("UTF-8") //parseHexBinary(masterKey)
     val cipher: Cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
-    val secretKey: SecretKeySpec = new SecretKeySpec(masterKeyBytes, "AES")
+    val secretKey: SecretKeySpec = new SecretKeySpec(masterKey.getBytes("UTF-8"), "AES")
 
     cipher.init(Cipher.ENCRYPT_MODE, secretKey)
     val ivString = printHexBinary(cipher.getIV)

--- a/src/main/scala/io/keen/client/scala/util/ScopedKeys.scala
+++ b/src/main/scala/io/keen/client/scala/util/ScopedKeys.scala
@@ -2,8 +2,7 @@ package io.keen.client.scala.util
 
 import javax.crypto.Cipher
 import javax.crypto.spec._
-
-import org.apache.commons.codec.binary.Hex
+import javax.xml.bind.DatatypeConverter.{parseHexBinary,printHexBinary}
 
 object ScopedKeys {
 
@@ -14,8 +13,8 @@ object ScopedKeys {
     val hexedIv = scopedKey.substring(0, 32)
     val hexedCipherText = scopedKey.substring(32)
 
-    val iv = Hex.decodeHex(hexedIv.toCharArray)
-    val cipherText = Hex.decodeHex(hexedCipherText.toCharArray)
+    val iv = parseHexBinary(hexedIv)
+    val cipherText = parseHexBinary(hexedCipherText)
 
     val secret = new SecretKeySpec(padApiKey(apiKey), "AES")
 
@@ -37,7 +36,7 @@ object ScopedKeys {
     val iv = cipher.getParameters.getParameterSpec(classOf[IvParameterSpec]).getIV
     val cipherText = cipher.doFinal(options.getBytes("UTF-8"))
 
-    Hex.encodeHexString(iv) + Hex.encodeHexString(cipherText)
+    printHexBinary(iv) + printHexBinary(cipherText)
   }
 
   private def padApiKey(key: String) = key.padTo(BLOCK_SIZE, " ").mkString.getBytes("UTF-8")

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -98,7 +98,7 @@ class ClientSpec extends Specification with NoTimeConversions {
   val dummyConfig = ConfigFactory.parseMap(
     Map(
       "keen.project-id" -> "abc",
-      "keen.optional.master-key" -> "masterKey",
+      "keen.optional.master-key" -> "master key exactly 32 chars long",
       "keen.optional.read-key" -> "readKey",
       "keen.optional.write-key" -> "writeKey"
     )
@@ -129,7 +129,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
       res.statusCode must beEqualTo(200)
       adapter.getUrl.get must beEqualTo("https://api.keen.io/3.0/projects")
-      adapter.getKey.get must beEqualTo("masterKey")
+      adapter.getKey.get must beEqualTo("master key exactly 32 chars long")
     }
 
     "handle get project" in {
@@ -137,7 +137,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
       res.statusCode must beEqualTo(200)
       adapter.getUrl.get must beEqualTo("https://api.keen.io/3.0/projects/abc")
-      adapter.getKey.get must beEqualTo("masterKey")
+      adapter.getKey.get must beEqualTo("master key exactly 32 chars long")
     }
 
     "handle get event" in {
@@ -145,7 +145,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
       res.statusCode must beEqualTo(200)
       adapter.getUrl.get must beEqualTo("https://api.keen.io/3.0/projects/abc/events")
-      adapter.getKey.get must beEqualTo("masterKey")
+      adapter.getKey.get must beEqualTo("master key exactly 32 chars long")
     }
 
     "handle get property" in {
@@ -153,7 +153,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
       res.statusCode must beEqualTo(200)
       adapter.getUrl.get must beEqualTo("https://api.keen.io/3.0/projects/abc/events/foo/properties/bar")
-      adapter.getKey.get must beEqualTo("masterKey")
+      adapter.getKey.get must beEqualTo("master key exactly 32 chars long")
     }
 
     "handle get collection" in {
@@ -161,7 +161,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
       res.statusCode must beEqualTo(200)
       adapter.getUrl.get must beEqualTo("https://api.keen.io/3.0/projects/abc/events/foo")
-      adapter.getKey.get must beEqualTo("masterKey")
+      adapter.getKey.get must beEqualTo("master key exactly 32 chars long")
     }
 
     "handle get collection (encoding)" in {
@@ -169,7 +169,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
       res.statusCode must beEqualTo(200)
       adapter.getUrl.get must beEqualTo("https://api.keen.io/3.0/projects/abc/events/foo%20foo")
-      adapter.getKey.get must beEqualTo("masterKey")
+      adapter.getKey.get must beEqualTo("master key exactly 32 chars long")
     }
 
     "handle count query" in {
@@ -177,8 +177,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
       res.statusCode must beEqualTo(200)
       adapter.getUrl.get must beEqualTo("https://api.keen.io/3.0/projects/abc/queries/count?event_collection=foo")
-
-      adapter.getKey.get must beEqualTo("masterKey")
+      adapter.getKey.get must beEqualTo("master key exactly 32 chars long")
     }
 
     // We'll test average thoroughly but since all the query method use the same underlying
@@ -206,7 +205,7 @@ class ClientSpec extends Specification with NoTimeConversions {
       url must contain("timezone=America/Chicago")
       url must contain("group_by=foo.name")
 
-      adapter.getKey.get must beEqualTo("masterKey")
+      adapter.getKey.get must beEqualTo("master key exactly 32 chars long")
     }
 
     "handle extraction query" in {
@@ -229,6 +228,18 @@ class ClientSpec extends Specification with NoTimeConversions {
       url must contain("email=test@example.com")
       url must contain("latest=1")
       url must contain("%5B%22abc%22,%22def%22%5D")
+    }
+
+    "generate a scoped key without filters" in {
+      val scopedKey = client.createScopedKey(Seq("read"))
+
+      scopedKey must not beNull
+    }
+
+    "generate a scoped key with filters" in {
+      val scopedKey = client.createScopedKey(Seq("read"), Some(Seq("""{"property_name": "baz", "operator": "eq", "property_value": "gorch"}""")))
+      
+      scopedKey must not beNull
     }
 
     "shutdown" in {
@@ -343,4 +354,3 @@ class ClientSpec extends Specification with NoTimeConversions {
     }
   }
 }
-


### PR DESCRIPTION
# What does this changeset do?

This changeset adds a method to `Client`s with the `Master` trait called `getScopedKey` that allows users to create [scoped keys](https://keen.io/docs/security/#scoped-key).

It also changes the dummy master key to be `master key exactly 32 chars long`, which has a 32-character length that is necessary for testing out the crypto stuff.

# Why does this changeset do that?

Someone might find it useful to generate scoped keys. You know, for security, or because they really enjoy unnecessary computations! And if they do, maybe they would also want to use Scala.

# Things to take note of

I used a `Seq[String]` for the allowed operations, and didn’t do any validation on them. I used an `Option[Seq[String]]` for the filters. I don’t really like this as a way to describe a Json object and would prefer Json-ifying a `Map` or something, but I think that’d mean an overhaul of a lot of things in this library.

# Tests

I tested these out anecdotally for myself, and added tests with and without filters to verify that the key creation doesn’t throw any errors. I’d love to know any other tests that I could write that spring to mind.