### PR TITLE
Code quality: fix lint warnings and enforce formatting style

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,3 +44,15 @@ initialCommands in consoleQuick := ""
 // SBT support for Maven-style integration tests (src/it)
 Defaults.itSettings
 configs(IntegrationTest)
+
+// Source Formatting
+import com.typesafe.sbt.SbtScalariform
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
+import scalariform.formatter.preferences._
+
+SbtScalariform.scalariformSettingsWithIt
+
+ScalariformKeys.preferences := ScalariformKeys.preferences.value
+  .setPreference(AlignSingleLineCaseStatements, true)
+  .setPreference(DoubleIndentClassDeclaration, true)
+  .setPreference(PreserveDanglingCloseParenthesis, true)

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalaVersion := "2.11.7"
 
 crossScalaVersions := Seq("2.10.6", scalaVersion.value)
 
-scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xlint")
 
 resolvers ++= Seq(
   "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
@@ -44,4 +44,3 @@ initialCommands in consoleQuick := ""
 // SBT support for Maven-style integration tests (src/it)
 Defaults.itSettings
 configs(IntegrationTest)
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
 

--- a/src/main/scala/io/keen/client/scala/AttemptCountingEventStore.scala
+++ b/src/main/scala/io/keen/client/scala/AttemptCountingEventStore.scala
@@ -1,9 +1,6 @@
 package io.keen.client.scala
 
 trait AttemptCountingEventStore extends EventStore {
-  
   def getAttempts(projectId: String, eventCollection: String): String
-
   def setAttempts(projectId: String, eventCollection: String, attemptsString: String): Unit
-
 }

--- a/src/main/scala/io/keen/client/scala/Client.scala
+++ b/src/main/scala/io/keen/client/scala/Client.scala
@@ -1,6 +1,6 @@
 package io.keen.client.scala
 
-import java.util.concurrent.{Executor, Executors, ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit}
+import java.util.concurrent.{Executors, ScheduledThreadPoolExecutor, TimeUnit}
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._

--- a/src/main/scala/io/keen/client/scala/Client.scala
+++ b/src/main/scala/io/keen/client/scala/Client.scala
@@ -1,13 +1,13 @@
 package io.keen.client.scala
 
-import java.util.concurrent.{Executors, ScheduledThreadPoolExecutor, TimeUnit}
+import java.util.concurrent.{ Executors, ScheduledThreadPoolExecutor, TimeUnit }
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 import grizzled.slf4j.Logging
 
 // XXX Remaining: Funnel, Saved Queries List, Saved Queries Row, Saved Queries Row Result
@@ -19,7 +19,7 @@ class Client(
     val scheme: String = "https",
     val authority: String = "api.keen.io",
     val version: String = "3.0"
-  ) extends HttpAdapterComponent with Logging {
+) extends HttpAdapterComponent with Logging {
 
   val httpAdapter: HttpAdapter = new HttpAdapterSpray
   val settings: Settings = new Settings(config)
@@ -77,7 +77,8 @@ sealed protected trait AccessLevel {
     method: String,
     key: String,
     body: Option[String] = None,
-    params: Map[String, Option[String]] = Map.empty) = {
+    params: Map[String, Option[String]] = Map.empty
+  ) = {
 
     httpAdapter.doRequest(method = method, scheme = scheme, authority = authority, path = path, key = key, body = body, params = params)
   }
@@ -125,7 +126,8 @@ trait Reader extends AccessLevel {
     filters: Option[String] = None,
     timeframe: Option[String] = None,
     timezone: Option[String] = None,
-    groupBy: Option[String]= None): Future[Response] =
+    groupBy: Option[String] = None
+  ): Future[Response] =
 
     doQuery(
       analysisType = "average",
@@ -134,7 +136,8 @@ trait Reader extends AccessLevel {
       filters = filters,
       timeframe = timeframe,
       timezone = timezone,
-      groupBy = groupBy)
+      groupBy = groupBy
+    )
 
   /**
    * Returns the number of resources in the event collection matching the given criteria. See [[https://keen.io/docs/api/reference/#event-resource Event Resource]].
@@ -148,7 +151,8 @@ trait Reader extends AccessLevel {
     filters: Option[String] = None,
     timeframe: Option[String] = None,
     timezone: Option[String] = None,
-    groupBy: Option[String]= None): Future[Response] =
+    groupBy: Option[String] = None
+  ): Future[Response] =
 
     doQuery(
       analysisType = "count",
@@ -157,7 +161,8 @@ trait Reader extends AccessLevel {
       filters = filters,
       timeframe = timeframe,
       timezone = timezone,
-      groupBy = groupBy)
+      groupBy = groupBy
+    )
 
   /**
    * Returns the number of '''unique''' resources in the event collection matching the given criteria. See [[https://keen.io/docs/api/reference/#event-resource Event Resource]].
@@ -175,7 +180,8 @@ trait Reader extends AccessLevel {
     filters: Option[String] = None,
     timeframe: Option[String] = None,
     timezone: Option[String] = None,
-    groupBy: Option[String]= None): Future[Response] =
+    groupBy: Option[String] = None
+  ): Future[Response] =
 
     doQuery(
       analysisType = "count",
@@ -184,7 +190,8 @@ trait Reader extends AccessLevel {
       filters = filters,
       timeframe = timeframe,
       timezone = timezone,
-      groupBy = groupBy)
+      groupBy = groupBy
+    )
 
   def extraction(
     collection: String,
@@ -192,7 +199,8 @@ trait Reader extends AccessLevel {
     timeframe: Option[String] = None,
     email: Option[String] = None,
     latest: Option[String] = None,
-    propertyNames: Option[String] = None): Future[Response] =
+    propertyNames: Option[String] = None
+  ): Future[Response] =
 
     doQuery(
       analysisType = "extraction",
@@ -220,7 +228,8 @@ trait Reader extends AccessLevel {
     filters: Option[String] = None,
     timeframe: Option[String] = None,
     timezone: Option[String] = None,
-    groupBy: Option[String]= None): Future[Response] =
+    groupBy: Option[String] = None
+  ): Future[Response] =
 
     doQuery(
       analysisType = "maximum",
@@ -229,7 +238,8 @@ trait Reader extends AccessLevel {
       filters = filters,
       timeframe = timeframe,
       timezone = timezone,
-      groupBy = groupBy)
+      groupBy = groupBy
+    )
 
   /**
    * Returns the minimum numeric value for the target property in the event collection matching the given criteria. See [[https://keen.io/docs/api/reference/#minimum-resource Minimum Resource]].
@@ -247,7 +257,8 @@ trait Reader extends AccessLevel {
     filters: Option[String] = None,
     timeframe: Option[String] = None,
     timezone: Option[String] = None,
-    groupBy: Option[String]= None): Future[Response] =
+    groupBy: Option[String] = None
+  ): Future[Response] =
 
     doQuery(
       analysisType = "minimum",
@@ -256,9 +267,10 @@ trait Reader extends AccessLevel {
       filters = filters,
       timeframe = timeframe,
       timezone = timezone,
-      groupBy = groupBy)
+      groupBy = groupBy
+    )
 
- /**
+  /**
    * Returns a list of '''unique''' resources in the event collection matching the given criteria. See [[https://keen.io/docs/api/reference/#select-unique-resource Select Unique Resource]].
    *
    * @param collection The name of the event collection you are analyzing.
@@ -274,7 +286,8 @@ trait Reader extends AccessLevel {
     filters: Option[String] = None,
     timeframe: Option[String] = None,
     timezone: Option[String] = None,
-    groupBy: Option[String]= None): Future[Response] =
+    groupBy: Option[String] = None
+  ): Future[Response] =
 
     doQuery(
       analysisType = "select_unique",
@@ -283,7 +296,8 @@ trait Reader extends AccessLevel {
       filters = filters,
       timeframe = timeframe,
       timezone = timezone,
-      groupBy = groupBy)
+      groupBy = groupBy
+    )
 
   /**
    * Returns the sum across all numeric values for the target property in the event collection matching the given criteria. See [[https://keen.io/docs/api/reference/#sum-resource Sum Resource]].
@@ -301,7 +315,8 @@ trait Reader extends AccessLevel {
     filters: Option[String] = None,
     timeframe: Option[String] = None,
     timezone: Option[String] = None,
-    groupBy: Option[String]= None): Future[Response] =
+    groupBy: Option[String] = None
+  ): Future[Response] =
 
     doQuery(
       analysisType = "sum",
@@ -310,7 +325,8 @@ trait Reader extends AccessLevel {
       filters = filters,
       timeframe = timeframe,
       timezone = timezone,
-      groupBy = groupBy)
+      groupBy = groupBy
+    )
 
   private def doQuery(
     analysisType: String,
@@ -322,7 +338,8 @@ trait Reader extends AccessLevel {
     groupBy: Option[String] = None,
     email: Option[String] = None,
     latest: Option[String] = None,
-    propertyNames: Option[String] = None): Future[Response] = {
+    propertyNames: Option[String] = None
+  ): Future[Response] = {
 
     val path = Seq(version, "projects", projectId, "queries", analysisType).mkString("/")
 
@@ -416,25 +433,23 @@ trait Writer extends AccessLevel {
    * @param event The event
    */
   def queueEvent(collection: String, event: String): Unit = {
-
     // bypass min/max intervals for testing
     environment match {
       case Some("test") if Some("test").get matches "(?i)test" => {}
       case _ =>
         require(sendIntervalEvents == 0 || (sendIntervalEvents >= MinSendIntervalEvents && sendIntervalEvents <= MaxSendIntervalEvents), s"Send events interval must be between $MinSendIntervalEvents and $MaxSendIntervalEvents")
     }
-    
+
     // write the event to the queue
     eventStore.store(projectId, collection, event)
-    
+
     // check the queue to see if we meet or exceed keen.optional.queue.send-interval.events. if so, send
     // all queued events
-    if(sendIntervalEvents != 0) {
-      if(eventStore.size >= sendIntervalEvents) {
+    if (sendIntervalEvents != 0) {
+      if (eventStore.size >= sendIntervalEvents) {
         sendQueuedEvents()
       }
     }
-
   }
 
   /**
@@ -442,7 +457,6 @@ trait Writer extends AccessLevel {
    * is between `MinSendIntervalSeconds` and `MaxSendIntervalSeconds`.
    */
   private def scheduleSendQueuedEvents(): Option[ScheduledThreadPoolExecutor] = {
-
     // bypass min/max intervals for testing
     environment match {
       case Some("test") if Some("test").get matches "(?i)test" => {}
@@ -462,8 +476,7 @@ trait Writer extends AccessLevel {
           def run: Unit = {
             try {
               sendQueuedEvents()
-            } 
-            catch {
+            } catch {
               case ex: Throwable => {
                 error("Failed to send queued events")
                 error(s"""$ex""")
@@ -474,33 +487,31 @@ trait Writer extends AccessLevel {
 
         Some(tp)
     }
-
   }
 
   /**
    * Sends all queued events, removing events from the queue as events are successfully sent.
    */
   def sendQueuedEvents(): Unit = {
-
     val handleMap: TrieMap[String, ListBuffer[Long]] = eventStore.getHandles(projectId)
     val handles: ListBuffer[Long] = ListBuffer.empty[Long]
     val events: ListBuffer[String] = ListBuffer.empty[String]
 
     // iterate over all of the event handles in the queue, by collection
-    for((collection, eventHandles) <- handleMap) {
-      // get each event, and its handle, then add it to a buffer so we can group the events 
+    for ((collection, eventHandles) <- handleMap) {
+      // get each event, and its handle, then add it to a buffer so we can group the events
       // into smaller batches
-      for(handle <- eventHandles) {
+      for (handle <- eventHandles) {
         handles += handle
         events += eventStore.get(handle)
       }
 
       // group handles separately so we can use them to remove events from the queue once they've
-      // been succesfully added
+      // been successfully added
       val handleGroup: List[ListBuffer[Long]] = handles.grouped(batchSize).toList
 
       // group the events by batch size, then publish them
-      for((batch, index) <- events.grouped(batchSize).zipWithIndex) {
+      for ((batch, index) <- events.grouped(batchSize).zipWithIndex) {
         // publish this batch
         var response = Await.result(
           addEvents(s"""{"$collection": [${batch.mkString(",")}]}"""),
@@ -514,7 +525,7 @@ trait Writer extends AccessLevel {
             info(s"""${response.statusCode} ${response.body} | Sent ${batch.size} queued events""")
 
             // remove all of the handles for this batch
-            for(handle <- handleGroup(index)) {
+            for (handle <- handleGroup(index)) {
               eventStore.remove(handle)
             }
 
@@ -523,19 +534,17 @@ trait Writer extends AccessLevel {
           }
           case _ => {
             // log but DO NOT remove events from queue
-            error(s"""${response.statusCode} ${response.body} | Failed to send ${batch.size} queued events""") 
+            error(s"""${response.statusCode} ${response.body} | Failed to send ${batch.size} queued events""")
           }
         }
       }
     }
-
   }
 
   /**
    * Asynchronously sends all queued events.
    */
   def sendQueuedEventsAsync(): Unit = {
-
     // use a thread pool for our async thread so we can use daemon threads
     val tp = Executors.newSingleThreadExecutor(new ClientThreadFactory)
 
@@ -545,21 +554,19 @@ trait Writer extends AccessLevel {
         sendQueuedEvents()
       }
     })
-
   }
 
   /**
    * Safely shuts down `scheduledThreadPool` before sending all events remaining in `eventStore`.
    */
   override def shutdown() = {
-
     // safely terminate the scheduled thread pool
     scheduledThreadPool match {
       case Some(stp) =>
         stp.shutdown
         stp.awaitTermination(shutdownDelay.toLong, TimeUnit.SECONDS) match {
           case false => error("Failed to shutdown scheduled thread pool")
-          case _ => {}
+          case _     => {}
         }
       case _ => {}
     }
@@ -569,9 +576,7 @@ trait Writer extends AccessLevel {
 
     // because we're overriding Client.shutdown
     httpAdapter.shutdown
-
   }
-
 }
 
 /**

--- a/src/main/scala/io/keen/client/scala/Client.scala
+++ b/src/main/scala/io/keen/client/scala/Client.scala
@@ -435,9 +435,12 @@ trait Writer extends AccessLevel {
   def queueEvent(collection: String, event: String): Unit = {
     // bypass min/max intervals for testing
     environment match {
-      case Some("test") if Some("test").get matches "(?i)test" => {}
+      case Some("test") if Some("test").get matches "(?i)test" =>
       case _ =>
-        require(sendIntervalEvents == 0 || (sendIntervalEvents >= MinSendIntervalEvents && sendIntervalEvents <= MaxSendIntervalEvents), s"Send events interval must be between $MinSendIntervalEvents and $MaxSendIntervalEvents")
+        require(
+          sendIntervalEvents == 0 || (sendIntervalEvents >= MinSendIntervalEvents && sendIntervalEvents <= MaxSendIntervalEvents),
+          s"Send events interval must be between $MinSendIntervalEvents and $MaxSendIntervalEvents"
+        )
     }
 
     // write the event to the queue
@@ -459,9 +462,12 @@ trait Writer extends AccessLevel {
   private def scheduleSendQueuedEvents(): Option[ScheduledThreadPoolExecutor] = {
     // bypass min/max intervals for testing
     environment match {
-      case Some("test") if Some("test").get matches "(?i)test" => {}
+      case Some("test") if Some("test").get matches "(?i)test" =>
       case _ =>
-        require(sendIntervalSeconds == 0 || (sendIntervalSeconds >= MinSendIntervalSeconds && sendIntervalSeconds <= MaxSendIntervalSeconds), s"Send seconds interval must be between $MinSendIntervalSeconds and $MaxSendIntervalSeconds")
+        require(
+          sendIntervalSeconds == 0 || (sendIntervalSeconds >= MinSendIntervalSeconds && sendIntervalSeconds <= MaxSendIntervalSeconds),
+          s"Send seconds interval must be between $MinSendIntervalSeconds and $MaxSendIntervalSeconds"
+        )
     }
 
     // send queued events every n seconds
@@ -473,14 +479,13 @@ trait Writer extends AccessLevel {
 
         // schedule sending from our thread pool at a specific interval
         tp.scheduleWithFixedDelay(new Runnable {
-          def run: Unit = {
+          def run(): Unit = {
             try {
               sendQueuedEvents()
             } catch {
-              case ex: Throwable => {
+              case ex: Throwable =>
                 error("Failed to send queued events")
                 error(s"""$ex""")
-              }
             }
           }
         }, 1, sendIntervalSeconds.toLong, TimeUnit.SECONDS)
@@ -520,7 +525,7 @@ trait Writer extends AccessLevel {
 
         // handle addEvents responses properly
         response.statusCode match {
-          case 200 | 201 => {
+          case 200 | 201 =>
             // log success
             info(s"""${response.statusCode} ${response.body} | Sent ${batch.size} queued events""")
 
@@ -531,11 +536,9 @@ trait Writer extends AccessLevel {
 
             // log removal
             info(s"""Removed ${handleGroup(index).size} events from the queue""")
-          }
-          case _ => {
-            // log but DO NOT remove events from queue
-            error(s"""${response.statusCode} ${response.body} | Failed to send ${batch.size} queued events""")
-          }
+
+          // log but DO NOT remove events from queue
+          case _ => error(s"""${response.statusCode} ${response.body} | Failed to send ${batch.size} queued events""")
         }
       }
     }
@@ -550,7 +553,7 @@ trait Writer extends AccessLevel {
 
     // send our queued events in a separate thread
     tp.execute(new Runnable {
-      def run: Unit = {
+      def run(): Unit = {
         sendQueuedEvents()
       }
     })
@@ -563,19 +566,19 @@ trait Writer extends AccessLevel {
     // safely terminate the scheduled thread pool
     scheduledThreadPool match {
       case Some(stp) =>
-        stp.shutdown
+        stp.shutdown()
         stp.awaitTermination(shutdownDelay.toLong, TimeUnit.SECONDS) match {
           case false => error("Failed to shutdown scheduled thread pool")
-          case _     => {}
+          case _     =>
         }
-      case _ => {}
+      case _ =>
     }
 
     // don't forget to empty the queue before we shutdown
     sendQueuedEvents()
 
     // because we're overriding Client.shutdown
-    httpAdapter.shutdown
+    httpAdapter.shutdown()
   }
 }
 

--- a/src/main/scala/io/keen/client/scala/ClientThreadFactory.scala
+++ b/src/main/scala/io/keen/client/scala/ClientThreadFactory.scala
@@ -3,7 +3,6 @@ package io.keen.client.scala
 import java.util.concurrent.ThreadFactory
 
 class ClientThreadFactory extends ThreadFactory {
-
   /**
    * Returns a new daemon thread.
    *
@@ -15,5 +14,4 @@ class ClientThreadFactory extends ThreadFactory {
     t.setDaemon(true)
     t
   }
-
 }

--- a/src/main/scala/io/keen/client/scala/EventStore.scala
+++ b/src/main/scala/io/keen/client/scala/EventStore.scala
@@ -7,18 +7,14 @@ import scala.collection.mutable.ListBuffer
  * Abstraction for implementing custom event stores.
  */
 trait EventStore {
-
   var maxEventsPerCollection: Integer = 10000
   var size: Integer = 0
 
-  def store(projectId: String,
-    eventCollection: String,
-    event: String): Long
+  def store(projectId: String, eventCollection: String, event: String): Long
 
   def get(handle: Long): String
 
   def remove(handle: Long): Unit
 
   def getHandles(projectId: String): TrieMap[String, ListBuffer[Long]]
-
 }

--- a/src/main/scala/io/keen/client/scala/HttpAdapterSpray.scala
+++ b/src/main/scala/io/keen/client/scala/HttpAdapterSpray.scala
@@ -7,7 +7,7 @@ import akka.util.Timeout
 import grizzled.slf4j.Logging
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
-import scala.util.{Failure,Success}
+import scala.util.{ Failure, Success }
 import spray.can.Http
 import spray.http._
 import spray.http.Uri._
@@ -15,7 +15,7 @@ import spray.http.HttpHeaders.RawHeader
 import spray.httpx.RequestBuilding._
 
 class HttpAdapterSpray(httpTimeoutSeconds: Int = 10)(implicit val actorSystem: ActorSystem = ActorSystem("keen-client"))
-  extends HttpAdapter with Logging {
+    extends HttpAdapter with Logging {
 
   import actorSystem.dispatcher // execution context for futures
 
@@ -30,7 +30,8 @@ class HttpAdapterSpray(httpTimeoutSeconds: Int = 10)(implicit val actorSystem: A
     method: String,
     key: String,
     body: Option[String] = None,
-    params: Map[String,Option[String]] = Map.empty): Future[Response] = {
+    params: Map[String, Option[String]] = Map.empty
+  ): Future[Response] = {
 
     // Turn a map of string,opt[string] into a map of string,string which is
     // what Query wants
@@ -53,9 +54,9 @@ class HttpAdapterSpray(httpTimeoutSeconds: Int = 10)(implicit val actorSystem: A
     // to construct an HTTP request of the type needed.
     val httpMethod: HttpRequest = method match {
       case "DELETE" => Delete(finalUrl, body)
-      case "GET" => Get(finalUrl, body)
-      case "POST" => Post(finalUrl, HttpEntity(ContentTypes.`application/json`, body.get))
-      case _ => throw new IllegalArgumentException("Unknown HTTP method: " + method)
+      case "GET"    => Get(finalUrl, body)
+      case "POST"   => Post(finalUrl, HttpEntity(ContentTypes.`application/json`, body.get))
+      case _        => throw new IllegalArgumentException("Unknown HTTP method: " + method)
     }
 
     debug("%s: %s".format(method, finalUrl))

--- a/src/main/scala/io/keen/client/scala/RamEventStore.scala
+++ b/src/main/scala/io/keen/client/scala/RamEventStore.scala
@@ -1,6 +1,5 @@
 package io.keen.client.scala
 
-import java.io.IOException
 import java.util.Locale
 
 import scala.collection.concurrent.TrieMap

--- a/src/main/scala/io/keen/client/scala/RamEventStore.scala
+++ b/src/main/scala/io/keen/client/scala/RamEventStore.scala
@@ -100,15 +100,15 @@ class RamEventStore extends AttemptCountingEventStore {
         val ids: ListBuffer[Long] = value
         var handles: ListBuffer[Long] = new ListBuffer[Long]()
         for (id <- ids) {
-          if (!events.keySet.exists(_ == id)) {
+          if (!events.keySet.contains(id)) {
             // lazily remove the "dead" event
             ids -= id
           } else {
-            handles += (id)
+            handles += id
           }
         }
 
-        if (handles.size > 0) {
+        if (handles.nonEmpty) {
           result += (eventCollection -> handles)
         }
       }

--- a/src/main/scala/io/keen/client/scala/RamEventStore.scala
+++ b/src/main/scala/io/keen/client/scala/RamEventStore.scala
@@ -10,7 +10,6 @@ import scala.util.control.Breaks._
  * In-memory queue for [[Client]].
  */
 class RamEventStore extends AttemptCountingEventStore {
-
   private var nextId: Long = 0
   private var collectionIds: TrieMap[String, ListBuffer[Long]] = new TrieMap[String, ListBuffer[Long]]()
   private var events: TrieMap[Long, String] = new TrieMap[Long, String]()
@@ -23,32 +22,34 @@ class RamEventStore extends AttemptCountingEventStore {
    * @param eventCollection The collection to which the event will be added.
    * @param event           The event.
    */
-  override def store(projectId: String,
+  override def store(
+    projectId: String,
     eventCollection: String,
-    event: String): Long = synchronized {
+    event: String
+  ): Long = synchronized {
 
-      // create a key from the project ID and event collection
-      val key = "%s$%s".formatLocal(Locale.US, projectId, eventCollection)
+    // create a key from the project ID and event collection
+    val key = "%s$%s".formatLocal(Locale.US, projectId, eventCollection)
 
-      // get the list of events for the specified key. if no list exists, create it
-      var collectionEvents: ListBuffer[Long] = collectionIds.getOrElse(key, null)
-      if(collectionEvents == null) {
-        collectionEvents = new ListBuffer[Long]()
-        collectionIds += (key -> collectionEvents)
-      }
+    // get the list of events for the specified key. if no list exists, create it
+    var collectionEvents: ListBuffer[Long] = collectionIds.getOrElse(key, null)
+    if (collectionEvents == null) {
+      collectionEvents = new ListBuffer[Long]()
+      collectionIds += (key -> collectionEvents)
+    }
 
-      // remove the oldest events until there is room for at least one more event
-      while(collectionEvents.size >= maxEventsPerCollection) {
-        var idToRemove = collectionEvents.remove(0)
-        events -= idToRemove
-      }
+    // remove the oldest events until there is room for at least one more event
+    while (collectionEvents.size >= maxEventsPerCollection) {
+      var idToRemove = collectionEvents.remove(0)
+      events -= idToRemove
+    }
 
-      // add the event to the event store, add its id to the collection's list, and return the id
-      var id = getNextId()
-      events += (id -> event)
-      size = events.size
-      collectionEvents += id
-      id
+    // add the event to the event store, add its id to the collection's list, and return the id
+    var id = getNextId()
+    events += (id -> event)
+    size = events.size
+    collectionEvents += id
+    id
   }
 
   /**
@@ -82,15 +83,12 @@ class RamEventStore extends AttemptCountingEventStore {
    * @return          A map of collection names and their events.
    */
   def getHandles(projectId: String): TrieMap[String, ListBuffer[Long]] = synchronized {
-    
     var result = new TrieMap[String, ListBuffer[Long]]()
-    
-    for((key, value) <- collectionIds) {
 
+    for ((key, value) <- collectionIds) {
       breakable {
-
         // skip collections for different projects
-        if(!key.startsWith(projectId)) {
+        if (!key.startsWith(projectId)) {
           break
         }
 
@@ -101,8 +99,8 @@ class RamEventStore extends AttemptCountingEventStore {
         // the result map
         val ids: ListBuffer[Long] = value
         var handles: ListBuffer[Long] = new ListBuffer[Long]()
-        for(id <- ids) {
-          if(!events.keySet.exists(_ == id)) {
+        for (id <- ids) {
+          if (!events.keySet.exists(_ == id)) {
             // lazily remove the "dead" event
             ids -= id
           } else {
@@ -110,36 +108,34 @@ class RamEventStore extends AttemptCountingEventStore {
           }
         }
 
-        if(handles.size > 0) {
+        if (handles.size > 0) {
           result += (eventCollection -> handles)
         }
-
-      } 
-
+      }
     }
-    
+
     result
   }
 
   def getAttempts(projectId: String, eventCollection: String): String = {
-    if(attempts == null) {
+    if (attempts == null) {
       return null
     }
 
     val project: TrieMap[String, String] = attempts.getOrElse(projectId, null)
-    if(project == null) {
+    if (project == null) {
       return null
     }
     project.getOrElse(eventCollection, null)
   }
 
   def setAttempts(projectId: String, eventCollection: String, attemptsString: String): Unit = {
-    if(attempts == null) {
+    if (attempts == null) {
       attempts = new TrieMap[String, TrieMap[String, String]]()
     }
 
     var project: TrieMap[String, String] = attempts.getOrElse(projectId, null)
-    if(project == null) {
+    if (project == null) {
       project = new TrieMap[String, String]()
       attempts += (projectId -> project)
     }
@@ -153,18 +149,18 @@ class RamEventStore extends AttemptCountingEventStore {
     events = new TrieMap[Long, String]()
   }
 
-  ///// PRIVATE /////  
+  ///// PRIVATE /////
 
   private def getNextId(): Long = {
     // it should be all but impossible for the event cache to grow bigger than Long.MaxValue,
     // but just for the sake of safe coding practices, check anyway
-    if(events.size > Long.MaxValue) {
+    if (events.size > Long.MaxValue) {
       throw new IllegalStateException("Event store exceeded maximum size")
     }
 
     // iterate through ids, starting with the next id counter, until an unused one is found
     var id = nextId
-    while(events.getOrElse(id, null) != null) {
+    while (events.getOrElse(id, null) != null) {
       id += 1
     }
 
@@ -174,10 +170,9 @@ class RamEventStore extends AttemptCountingEventStore {
   }
 
   private def handleToId(handle: Long): Long = {
-    if(!handle.isInstanceOf[Long]) {
+    if (!handle.isInstanceOf[Long]) {
       throw new IllegalArgumentException("Expected handle to be a Long, but was: " + handle.getClass.getCanonicalName)
     }
     handle.asInstanceOf[Long]
   }
-
 }

--- a/src/main/scala/io/keen/client/scala/RamEventStore.scala
+++ b/src/main/scala/io/keen/client/scala/RamEventStore.scala
@@ -148,7 +148,7 @@ class RamEventStore extends AttemptCountingEventStore {
     project += (eventCollection -> attemptsString)
   }
 
-  def clear() {
+  def clear(): Unit = {
     nextId = 0
     collectionIds = new TrieMap[String, ListBuffer[Long]]()
     events = new TrieMap[Long, String]()

--- a/src/main/scala/io/keen/client/scala/Settings.scala
+++ b/src/main/scala/io/keen/client/scala/Settings.scala
@@ -29,6 +29,8 @@ class Settings(config: Config) {
 
   val environment: Option[String] = config.getOptionalString("keen.optional.environment")
 
+  // format: OFF
+
   val masterKey: Option[String] = config.getOptionalString("keen.optional.master-key")
   val readKey: Option[String]   = config.getOptionalString("keen.optional.read-key")
   val writeKey: Option[String]  = config.getOptionalString("keen.optional.write-key")

--- a/src/main/scala/io/keen/client/scala/package.scala
+++ b/src/main/scala/io/keen/client/scala/package.scala
@@ -19,7 +19,8 @@ package object scala {
       else None
     }
   }
-
-  case class MissingCredential(cause: String) extends RuntimeException(cause)
 }
 
+package scala {
+  case class MissingCredential(cause: String) extends RuntimeException(cause)
+}

--- a/src/main/scala/io/keen/client/scala/package.scala
+++ b/src/main/scala/io/keen/client/scala/package.scala
@@ -1,6 +1,6 @@
 package io.keen.client
 
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.Config
 
 package object scala {
   /**

--- a/src/test/scala/AttemptCountingEventStoreSpecBase.scala
+++ b/src/test/scala/AttemptCountingEventStoreSpecBase.scala
@@ -5,7 +5,7 @@ import io.keen.client.scala.AttemptCountingEventStore
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 
-import org.specs2.mutable.{BeforeAfter, Specification}
+import org.specs2.mutable.BeforeAfter
 
 abstract class AttemptCountingEventStoreSpecBase extends EventStoreSpecBase {
 

--- a/src/test/scala/AttemptCountingEventStoreSpecBase.scala
+++ b/src/test/scala/AttemptCountingEventStoreSpecBase.scala
@@ -8,41 +8,34 @@ import scala.collection.mutable.ListBuffer
 import org.specs2.mutable.BeforeAfter
 
 abstract class AttemptCountingEventStoreSpecBase extends EventStoreSpecBase {
-
   var attemptCountingStore: AttemptCountingEventStore = _
-  
-  trait AttemptCountingEventStoreSetupTeardown extends BeforeAfter {
 
+  trait AttemptCountingEventStoreSetupTeardown extends BeforeAfter {
     def before: Any = {
-      store = buildStore()  // initialize our store
+      store = buildStore() // initialize our store
       attemptCountingStore = store.asInstanceOf[AttemptCountingEventStore]
     }
 
     def after: Any = {}
-
   }
 
   sequential
 
   "AttemptCountingEventStore" should {
-
     "store and get event attempts" in new AttemptCountingEventStoreSetupTeardown {
-
       val attempts: String = "blargh"
       attemptCountingStore.setAttempts("project1", "collection1", attempts)
       attempts must beEqualTo(attemptCountingStore.getAttempts("project1", "collection1"))
-
     }
-    
-    "get handles with attempts" in new AttemptCountingEventStoreSetupTeardown {
 
+    "get handles with attempts" in new AttemptCountingEventStoreSetupTeardown {
       // add a couple events to the store
       attemptCountingStore.store("project1", "collection1", testEvents(0))
       attemptCountingStore.store("project1", "collection2", testEvents(1))
 
       // set some value for attempts.json. this is to ensure that setting attempts doesn't
       // interfere with getting handles
-      attemptCountingStore.setAttempts("project1", "collection1", "{}");
+      attemptCountingStore.setAttempts("project1", "collection1", "{}")
 
       // get the handle map
       val handleMap: TrieMap[String, ListBuffer[Long]] = attemptCountingStore.getHandles("project1")
@@ -60,8 +53,6 @@ abstract class AttemptCountingEventStoreSpecBase extends EventStoreSpecBase {
       // validate the actual events
       store.get(handles1(0)) must beEqualTo(testEvents(0))
       store.get(handles2(0)) must beEqualTo(testEvents(1))
-
     }
-
   }
 }

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -35,7 +35,8 @@ class ClientSpec extends Specification with NoTimeConversions {
       method: String,
       key: String,
       body: Option[String] = None,
-      params: Map[String,Option[String]] = Map.empty): Future[Response] = {
+      params: Map[String, Option[String]] = Map.empty
+    ): Future[Response] = {
 
       // We have a map of str,opt[str] and we need to convert it to
       val filteredParams = params.filter(
@@ -74,7 +75,7 @@ class ClientSpec extends Specification with NoTimeConversions {
       method: String,
       key: String,
       body: Option[String] = None,
-      params: Map[String,Option[String]] = Map.empty
+      params: Map[String, Option[String]] = Map.empty
     ): Future[Response] = {
       Future {
         Response(500, "Internal Server Error")
@@ -91,7 +92,7 @@ class ClientSpec extends Specification with NoTimeConversions {
       method: String,
       key: String,
       body: Option[String] = None,
-      params: Map[String,Option[String]] = Map.empty
+      params: Map[String, Option[String]] = Map.empty
     ): Future[Response] = {
       Future.failed(new AskTimeoutException("I timed out!"))
     }
@@ -109,7 +110,7 @@ class ClientSpec extends Specification with NoTimeConversions {
   // generates n test events
   def generateTestEvents(n: Integer): ListBuffer[String] = {
     val events: ListBuffer[String] = new ListBuffer[String]
-    for(i <- 1 to n) {
+    for (i <- 1 to n) {
       events += s"""{"param$i":"value$i"}"""
     }
     events
@@ -315,7 +316,7 @@ class ClientSpec extends Specification with NoTimeConversions {
 
     "send queued events" in {
 
-      testEvents = generateTestEvents(5)      
+      testEvents = generateTestEvents(5)
       testEvents.foreach { event => client.queueEvent(collection, event) }
 
       // verify that the expected number of events are in the store
@@ -342,9 +343,9 @@ class ClientSpec extends Specification with NoTimeConversions {
     "automatically send queued events when queue reaches keen.optional.queue.send-interval.events" in {
 
       testEvents = generateTestEvents(100)
-      
+
       // queue the first 50 events
-      for(i <- 0 to 49) {
+      for (i <- 0 to 49) {
         client.queueEvent(collection, testEvents(i))
       }
 
@@ -354,7 +355,7 @@ class ClientSpec extends Specification with NoTimeConversions {
       handleMap.getOrElse(collection, null).size must beEqualTo(50)
 
       // add the final 50 events
-      for(i <- 50 to 99) {
+      for (i <- 50 to 99) {
         client.queueEvent(collection, testEvents(i))
       }
 
@@ -362,7 +363,7 @@ class ClientSpec extends Specification with NoTimeConversions {
       // triggered with the queueing of the 100th event
       handleMap = store.getHandles(projectId)
       handleMap.size must beEqualTo(0)
-      
+
     }
 
     "automatically send queued events every keen.optional.queue.send-interval.seconds" in {
@@ -382,7 +383,7 @@ class ClientSpec extends Specification with NoTimeConversions {
       // triggered with the queueing of the 100th event
       handleMap = store.getHandles(projectId)
       handleMap.size must beEqualTo(0)
-      
+
     }
 
     "send queued events on shutdown" in {
@@ -507,9 +508,9 @@ class ClientSpec extends Specification with NoTimeConversions {
       val projectId: String = dummyConfig.getString("keen.project-id")
       val collection: String = "foo"
       val testEvents: ListBuffer[String] = generateTestEvents(5)
-      
+
       // queue the events
-      for(event <- testEvents) {
+      for (event <- testEvents) {
         client.queueEvent(collection, event)
       }
 

--- a/src/test/scala/EventStoreSpecBase.scala
+++ b/src/test/scala/EventStoreSpecBase.scala
@@ -12,7 +12,7 @@ import org.specs2.specification.{ Step, Fragments }
 
 trait BeforeAllAfterAll extends Specification {
   override def map(fragments: => Fragments) =
-    Step(beforeAll) ^ fragments ^ Step(afterAll)
+    Step(beforeAll()) ^ fragments ^ Step(afterAll())
 
   protected def beforeAll(): Unit
   protected def afterAll(): Unit
@@ -52,20 +52,20 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
 
   "EventStoreSpecBase" should {
     "store and get event" in new EventStoreSetupTeardown {
-      val handle: Long = store.store("project1", "collection1", testEvents(0))
+      val handle: Long = store.store("project1", "collection1", testEvents.head)
       val retrieved: String = store.get(handle)
-      retrieved must beEqualTo(testEvents(0))
+      retrieved must beEqualTo(testEvents.head)
     }
 
     "remove event" in new EventStoreSetupTeardown {
-      val handle: Long = store.store("project1", "collection1", testEvents(0))
+      val handle: Long = store.store("project1", "collection1", testEvents.head)
       store.remove(handle)
       val retrieved: String = store.get(handle)
-      (retrieved must beNull)
+      retrieved must beNull
     }
 
     "remove handle twice" in new EventStoreSetupTeardown {
-      val handle: Long = store.store("project1", "collection1", testEvents(0))
+      val handle: Long = store.store("project1", "collection1", testEvents.head)
       store.remove(handle)
       store.remove(handle)
       true must beEqualTo(true) // we're testing for an exception here, and if none is thrown, pass
@@ -73,7 +73,7 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
 
     "get handles" in new EventStoreSetupTeardown {
       // add a couple events to the store
-      store.store("project1", "collection1", testEvents(0))
+      store.store("project1", "collection1", testEvents.head)
       store.store("project1", "collection2", testEvents(1))
 
       // get the handle map
@@ -90,8 +90,8 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
       handles2.size must beEqualTo(1)
 
       // validate the actual events
-      store.get(handles1(0)) must beEqualTo(testEvents(0))
-      store.get(handles2(0)) must beEqualTo(testEvents(1))
+      store.get(handles1.head) must beEqualTo(testEvents.head)
+      store.get(handles2.head) must beEqualTo(testEvents(1))
     }
 
     "get handles with no events" in new EventStoreSetupTeardown {
@@ -102,7 +102,7 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
 
     "get handles for multiple projects" in new EventStoreSetupTeardown {
       // add a couple events to the store in different projects
-      store.store("project1", "collection1", testEvents(0))
+      store.store("project1", "collection1", testEvents.head)
       store.store("project1", "collection2", testEvents(1))
       store.store("project2", "collection3", testEvents(2))
       store.store("project2", "collection3", testEvents(3))

--- a/src/test/scala/EventStoreSpecBase.scala
+++ b/src/test/scala/EventStoreSpecBase.scala
@@ -11,13 +11,11 @@ import org.specs2.mutable.{BeforeAfter, Specification}
 import org.specs2.specification.{Step, Fragments}
 
 trait BeforeAllAfterAll extends Specification {
-
   override def map(fragments: => Fragments) =
     Step(beforeAll) ^ fragments ^ Step(afterAll)
 
-  protected def beforeAll()
-  protected def afterAll()
-
+  protected def beforeAll(): Unit
+  protected def afterAll(): Unit
 }
 
 abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
@@ -28,7 +26,7 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
   var store: EventStore = _
   val testEvents: ListBuffer[String] = new ListBuffer[String]
 
-  def beforeAll() {
+  def beforeAll() = {
     store = buildStore()  // initialize our store
 
     // generate 5 test events and add them to the store and keep track of them so
@@ -38,7 +36,7 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
     }
   }
 
-  def afterAll() {
+  def afterAll() = {
     store = null  // cleanup
   }
 

--- a/src/test/scala/EventStoreSpecBase.scala
+++ b/src/test/scala/EventStoreSpecBase.scala
@@ -7,8 +7,8 @@ import java.io.IOException
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 
-import org.specs2.mutable.{BeforeAfter, Specification}
-import org.specs2.specification.{Step, Fragments}
+import org.specs2.mutable.{ BeforeAfter, Specification }
+import org.specs2.specification.{ Step, Fragments }
 
 trait BeforeAllAfterAll extends Specification {
   override def map(fragments: => Fragments) =
@@ -27,61 +27,51 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
   val testEvents: ListBuffer[String] = new ListBuffer[String]
 
   def beforeAll() = {
-    store = buildStore()  // initialize our store
+    store = buildStore() // initialize our store
 
     // generate 5 test events and add them to the store and keep track of them so
     // we can use them later in the test
-    for(i <- 0 to 4) {
+    for (i <- 0 to 4) {
       testEvents += s"""{"param$i":"value$i"}"""
     }
   }
 
   def afterAll() = {
-    store = null  // cleanup
+    store = null // cleanup
   }
 
   trait EventStoreSetupTeardown extends BeforeAfter {
-
     def before: Any = {
-      store = buildStore()  // initialize our store
+      store = buildStore() // initialize our store
     }
 
     def after: Any = {}
-
   }
 
   sequential
 
   "EventStoreSpecBase" should {
-
     "store and get event" in new EventStoreSetupTeardown {
-
       val handle: Long = store.store("project1", "collection1", testEvents(0))
       val retrieved: String = store.get(handle)
       retrieved must beEqualTo(testEvents(0))
-
     }
 
     "remove event" in new EventStoreSetupTeardown {
-
       val handle: Long = store.store("project1", "collection1", testEvents(0))
       store.remove(handle)
       val retrieved: String = store.get(handle)
       (retrieved must beNull)
-
     }
 
     "remove handle twice" in new EventStoreSetupTeardown {
-
       val handle: Long = store.store("project1", "collection1", testEvents(0))
       store.remove(handle)
       store.remove(handle)
       true must beEqualTo(true) // we're testing for an exception here, and if none is thrown, pass
-
     }
 
     "get handles" in new EventStoreSetupTeardown {
-
       // add a couple events to the store
       store.store("project1", "collection1", testEvents(0))
       store.store("project1", "collection2", testEvents(1))
@@ -102,19 +92,15 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
       // validate the actual events
       store.get(handles1(0)) must beEqualTo(testEvents(0))
       store.get(handles2(0)) must beEqualTo(testEvents(1))
-
     }
 
     "get handles with no events" in new EventStoreSetupTeardown {
-
       val handleMap: TrieMap[String, ListBuffer[Long]] = store.getHandles("project1")
       (handleMap must not beNull)
       handleMap.size must beEqualTo(0)
-
     }
 
     "get handles for multiple projects" in new EventStoreSetupTeardown {
-
       // add a couple events to the store in different projects
       store.store("project1", "collection1", testEvents(0))
       store.store("project1", "collection2", testEvents(1))
@@ -133,9 +119,6 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
       (handleMap must not beNull)
       handleMap.size must beEqualTo(1)
       handleMap.getOrElse("collection3", null).size must beEqualTo(2)
-
     }
-
   }
-
 }

--- a/src/test/scala/RamEventStoreSpec.scala
+++ b/src/test/scala/RamEventStoreSpec.scala
@@ -6,8 +6,6 @@ import io.keen.client.scala.RamEventStore
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 
-import org.specs2.mutable.Specification
-
 class RamEventStoreSpec extends AttemptCountingEventStoreSpecBase {
 
   override def buildStore(): EventStore = {

--- a/src/test/scala/RamEventStoreSpec.scala
+++ b/src/test/scala/RamEventStoreSpec.scala
@@ -7,7 +7,6 @@ import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 
 class RamEventStoreSpec extends AttemptCountingEventStoreSpecBase {
-
   override def buildStore(): EventStore = {
     new RamEventStore
   }
@@ -15,17 +14,15 @@ class RamEventStoreSpec extends AttemptCountingEventStoreSpecBase {
   sequential
 
   "RamEventStore" should {
-
     "not exceed the maximum number of events per collection" in {
-
       val ramStore: EventStore = store.asInstanceOf[RamEventStore]
       ramStore.maxEventsPerCollection = 3
 
       // add 5 events
-      for(i <- 0 to 4) {
+      for (i <- 0 to 4) {
         store.store("project1", "collection1", testEvents(i))
       }
-      
+
       // get the handle map
       val handleMap: TrieMap[String, ListBuffer[Long]] = ramStore.getHandles("project1")
       (handleMap must not beNull)
@@ -37,7 +34,7 @@ class RamEventStoreSpec extends AttemptCountingEventStoreSpecBase {
 
       // get the events
       val retrievedEvents: ListBuffer[String] = new ListBuffer[String]()
-      for(handle <- handles) {
+      for (handle <- handles) {
         val retrievedEvent: String = ramStore.get(handle)
         (retrievedEvent must not beNull)
         retrievedEvents += retrievedEvent
@@ -46,8 +43,6 @@ class RamEventStoreSpec extends AttemptCountingEventStoreSpecBase {
       // validate that there are a total of 3 events in RamEventStore, the last 3
       // we added in fact, because the first 2 have already been purged from the store
       retrievedEvents must contain(allOf(testEvents(2), testEvents(3), testEvents(4)))
-
     }
-    
   }
 }


### PR DESCRIPTION
I noticed a bunch of inconsistent code formatting after recent changes, so I added the [Scalariform SBT plugin][1] to automatically format code upon `sbt compile`. I took the liberty of setting a few preferences that I happen to like (which incidentally are the same as [the sbt-scalariform projects's own settings][2]), but I don't particularly care what the settings are, I'd just like what is expected in code reviews to be unambiguous so it isn't a distraction. You can [peruse the available preference settings][3] in case you wish to suggest something different.

This also turns on the `-Xlint` compiler option and fixes a few complaints it raised. See `scalac -Xlint:help` for a summary of common pitfalls it helps to catch.

For now this is passively enforced, I didn't want to get too opinionated without consensus. We could add `-Xfatal-warnings` to the `scalacOptions` to cause lint warnings to fail CI builds. `sbt-scalariform` doesn't expose a similar feature, yet, but [there is talk of it][4].

There is also [Scalastyle][5] which somewhat confusingly mixes source code formatting checks and other static analysis checks. It doesn't actually *apply* source formatting AFAICT, and has a bunch of (XML) configuration that might be contentious to bikeshed over, so I didn't go so far as adding it here, yet. It might be worth discussing though, since it does offer a few useful code quality checks (for an open source library, I particularly like the check for missing ScalaDoc). It does have a setting to fail SBT builds.

[1]: https://github.com/sbt/sbt-scalariform
[2]: https://github.com/sbt/sbt-scalariform/blob/61a0b7b75441b458e4ff3c6c30ed87d087a2e569/scalariform.sbt
[3]: http://scala-ide.org/scalariform/#preferences
[4]: https://github.com/sbt/sbt-scalariform/issues/35
[5]: http://www.scalastyle.org/