### PR TITLE
Improved type specificity of config values for batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-**Note:** you might notice that `1.0.x` tags were used early on in the life of this project. Ignore them. No release artifacts were published for those tags. The first published artifact was version `0.4.0`. 
+**Note:** you might notice that `1.0.x` tags were used early on in the life of this project. Ignore them. No release artifacts were published for those tags. The first published artifact was version `0.4.0`.
 
 
 ## [Unreleased][unreleased]
 ### Changed
+- Improved CHANGELOG.md format
 - Updated Scala & SBT versions
-- Improved CHANGELOG.md
+- Improved type specificity of config values for batched writes, like time durations
 
 ## [0.6.0] - 2016-02-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ can set env vars for app processes with ease. On Heroku you'll be right at home.
 * `keen.optional.read-key`: Your project read key.
 * `keen.optional.write-key`: Your project write key.
 * `keen.optional.master-key`: Your project master key.
-* `keen.optional.queue.batch.size`: Number of events to include in each batch sent by `sendQueuedEvents()`. Default is `500`.
-* `keen.optional.queue.batch.timeout`: Seconds each batch sent by `sendQueuedEvents()` should wait before the request times out. Default is `5`.
-* `keen.optional.queue.max-events-per-collection`: Maximum number of events to store for each collection. Old events are purged from the queue to make room for new events when the size of the queue exceeds this number. Default is `10000`.
-* `keen.optional.queue.send-interval.events`: Automatically send all queued events every time the queue reaches this number. Minimum is `100`, maximum is `10000`, and default is `0`.
-* `keen.optional.queue.send-interval.seconds`: Automatically send all queued events at a specified interval. Minimum is `60`, maximum is `3600`, and default is `0`.
-* `keen.optional.queue.shutdown-delay`: Seconds to wait before client stops attempting to send events scheduled to be sent at a specific interval. Default is `30`.
+* `keen.queue.batch.size`: Number of events to include in each batch sent by `sendQueuedEvents()`. Default is `500`.
+* `keen.queue.batch.timeout`: Duration that each batch sent by `sendQueuedEvents()` should wait before the request times out. Default is 5 seconds.
+* `keen.queue.max-events-per-collection`: Maximum number of events to store for each collection. Old events are purged from the queue to make room for new events when the size of the queue exceeds this number. Default is `10000`.
+* `keen.queue.send-interval.events`: Automatically send all queued events every time the queue reaches this number. Minimum is `100`, maximum is `10000`, and default is `0`.
+* `keen.queue.send-interval.duration`: Automatically send all queued events at a specified interval. Minimum is 60 seconds, maximum is 3600, and default is 0.
+* `keen.queue.shutdown-delay`: Duration before client stops attempting to send events scheduled to be sent at a specific interval. Default is 30 seconds.
 
 ## Use It - A Quick Taste
 
@@ -147,17 +147,17 @@ keen.sendQueuedEvents()
 
 **Sending queued events every time the queue reaches 100 events**
 
-Set `keen.optional.queue.send-interval.events` equal to `100` in `conf/application.conf`.
+Set `keen.queue.send-interval.events` equal to `100` in `conf/application.conf`.
 
 **Sending queued events every 5 minutes**
 
-Set `keen.optional.queue.send-interval.seconds` equal to `300` in `conf/application.conf`.
+Set `keen.queue.send-interval.duration` equal to `5 minutes` in `conf/application.conf`.
 
-Note that `send-interval.events` takes precedence when both `send-interval.events` and `send-interval.seconds` contain values greater than zero.
+Note that `send-interval.events` takes precedence when both `send-interval.events` and `send-interval.duration` contain values greater than zero.
 
 **Using batch sizes**
 
-Setting a specific batch size will help optimize your experience when sending events. It's recommended that you set `keen.optional.queue.batch.size` to something that makes sense for your implementation (default is `500`). Note that a batch size of `5000` is the upper bound of what you should shoot for. Anything higher and your request has a good chance of being rejected due to payload size limitations.
+Setting a specific batch size will help optimize your experience when sending events. It's recommended that you set `keen.queue.batch.size` to something that makes sense for your implementation (default is `500`). Note that a batch size of `5000` is the upper bound of what you should shoot for. Anything higher and your request has a good chance of being rejected due to payload size limitations.
 
 **Failed events**
 
@@ -241,4 +241,3 @@ that you didn't expect!**
 [sbt-dotenv]: https://github.com/mefellows/sbt-dotenv
 [global plugin]: http://www.scala-sbt.org/0.13/docs/Global-Settings.html
 [runit]: http://smarden.org/runit/
-

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -6,20 +6,29 @@ keen {
     master-key = ${?KEEN_MASTER_KEY}
     read-key = ${?KEEN_READ_KEY}
     write-key = ${?KEEN_WRITE_KEY}
+  }
 
-    # configuration for local event store queue
-    queue {
-      batch {
-        size = ${?KEEN_EVENT_QUEUE_BATCH_SIZE}
-        timeout = ${?KEEN_EVENT_QUEUE_BATCH_TIMEOUT}
-      }
-      max-events-per-collection = ${?KEEN_EVENT_QUEUE_MAX_EVENTS_PER_COLLECTION}
-      send-interval {
-        events = ${?KEEN_EVENT_QUEUE_SEND_INTERVAL_EVENTS}
-        seconds = ${?KEEN_EVENT_QUEUE_SEND_INTERVAL_SECONDS}
-      }
-      shutdown-delay = ${?KEEN_EVENT_QUEUE_SHUTDOWN_DELAY}
+  # Queue and flushing behavior for writer clients when batching
+  queue {
+    batch {
+      size = 500
+      size = ${?KEEN_EVENT_QUEUE_BATCH_SIZE}
+
+      timeout = 5 seconds
+      timeout = ${?KEEN_EVENT_QUEUE_BATCH_TIMEOUT}
     }
+
+    max-events-per-collection = 10000
+    max-events-per-collection = ${?KEEN_EVENT_QUEUE_MAX_EVENTS_PER_COLLECTION}
+
+    send-interval {
+      events = 0
+      events = ${?KEEN_EVENT_QUEUE_SEND_INTERVAL_EVENTS}
+      duration = 0s
+      duration = ${?KEEN_EVENT_QUEUE_SEND_INTERVAL_DURATION}
+    }
+
+    shutdown-delay = 30 seconds
+    shutdown-delay = ${?KEEN_EVENT_QUEUE_SHUTDOWN_DELAY}
   }
 }
-

--- a/src/main/scala/io/keen/client/scala/Settings.scala
+++ b/src/main/scala/io/keen/client/scala/Settings.scala
@@ -1,5 +1,7 @@
 package io.keen.client.scala
 
+import scala.concurrent.duration.FiniteDuration
+
 import com.typesafe.config._
 
 /**
@@ -35,12 +37,11 @@ class Settings(config: Config) {
   val readKey: Option[String]   = config.getOptionalString("keen.optional.read-key")
   val writeKey: Option[String]  = config.getOptionalString("keen.optional.write-key")
 
-  // Writer specific settings
-  val batchSize: Option[Integer] = config.getOptionalInt("keen.optional.queue.batch.size")
-  val batchTimeout: Option[Integer] = config.getOptionalInt("keen.optional.queue.batch.timeout")
-  val maxEventsPerCollection: Option[Integer] = config.getOptionalInt("keen.optional.queue.max-events-per-collection")
-  val sendIntervalEvents: Option[Integer] = config.getOptionalInt("keen.optional.queue.send-interval.events")
-  val sendIntervalSeconds: Option[Integer] = config.getOptionalInt("keen.optional.queue.send-interval.seconds")
-  val shutdownDelay: Option[Integer] = config.getOptionalInt("keen.optional.queue.shutdown-delay")
+  // Writer-specific settings
+  val batchSize: Integer                   = config.getInt("keen.queue.batch.size")
+  val batchTimeout: FiniteDuration         = config.getFiniteDuration("keen.queue.batch.timeout")
+  val maxEventsPerCollection: Integer      = config.getInt("keen.queue.max-events-per-collection")
+  val sendIntervalEvents: Integer          = config.getInt("keen.queue.send-interval.events")
+  val sendIntervalDuration: FiniteDuration = config.getFiniteDuration("keen.queue.send-interval.duration")
+  val shutdownDelay: FiniteDuration        = config.getFiniteDuration("keen.queue.shutdown-delay")
 }
-

--- a/src/main/scala/io/keen/client/scala/package.scala
+++ b/src/main/scala/io/keen/client/scala/package.scala
@@ -1,13 +1,16 @@
 package io.keen.client
 
+import concurrent.duration.{ FiniteDuration, MILLISECONDS }
+
 import com.typesafe.config.Config
 
 package object scala {
   /**
-   * Enrichment for Typesafe Config to wrap some optional settings in Option.
+   * Enrichment for Typesafe Config to wrap some optional settings in Option, or
+   * get Scala `FiniteDuration` values instead of `java.time.Duration`.
    *
-   * @internal Could use [[https://github.com/ceedubs/ficus Ficus]] for fancy
-   * stuff, but for simple Options for now this is lighter.
+   * @internal Could use [[https://github.com/iheartradio/ficus Ficus]] for
+   *   fancier stuff, but for a few simple needs this is lighter for now.
    */
   implicit class RichConfig(val self: Config) extends AnyVal {
     def getOptionalString(path: String): Option[String] = {
@@ -17,6 +20,10 @@ package object scala {
     def getOptionalInt(path: String): Option[Integer] = {
       if (self.hasPath(path)) Some(self.getInt(path))
       else None
+    }
+    def getFiniteDuration(path: String): FiniteDuration = {
+      val millis = self.getDuration(path, java.util.concurrent.TimeUnit.MILLISECONDS)
+      FiniteDuration(millis, MILLISECONDS)
     }
   }
 }


### PR DESCRIPTION
I was still taking a closer look at #38 and felt we could do better with the types of the config settings. So this change does primarily three things:

- Uses `FiniteDuration` to represent config values that are clearly time durations.
- Moves all default setting values to `reference.conf` as I had mentioned in review on #38. This is [a strong philosophy of Typesafe Config][2] to avoid having defaults spread opaquely throughout a code base, prone to copy-and-paste bugs when `getOrElse` calls proliferate.
- Moves all the `queue.batch` settings out from under the `optional` hierarchy, and they are no longer wrapped in `Option`—rationale for this is also supported by the same link above: because we provide default values for all of them, they don't need to be optional. Optional settings lead to pains with being able to validate as early as possible (client instantiation time) that all needed settings are present, possibly leading to much later runtime errors if we can't do it. Earlier in #25 I created the explicit `optional` subtree for the read/write/master keys to make it really obvious when this grows—clearly many client deployments never need e.g. a master key and it is security-sensitive, so these truly are optional (and I went to lengths to make sure client instantiation still fails fast if a needed key is missing).

**Note**: This is based on my branch that applies Scalariform in #42, so it's better to see the changes added in this branch [with this comparison view][1]. I'll rebase this pending a decision on that other PR so that it's easier to review directly here.

[1]: https://github.com/ches/KeenClient-Scala/compare/lint-and-style...ches:batching-config-types
[2]: https://github.com/typesafehub/config#how-to-handle-defaults