### PR TITLE
Move batched write support to a subclass of Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Improved CHANGELOG.md format
 - Updated Scala & SBT versions
-- Improved type specificity of config values for batched writes, like time durations
+- Improved type specificity of config values for batched writes, like time durations - #44
+- Moved batched write (queueing) functionality to a subclass of client, called `BatchWriterClient` - #45
 
 ## [0.6.0] - 2016-02-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Improved CHANGELOG.md format
 - Updated Scala & SBT versions
 - Improved type specificity of config values for batched writes, like time durations - #44
-- Moved batched write (queueing) functionality to a subclass of client, called `BatchWriterClient` - #45
+- Moved batched write (queueing) functionality to a subclass of client, called `BatchWriterClient`. The `queueEvent` method no longer intermittently blocks to synchronously flush the queue if event count threshold is reached when it is called. - #45
 
 ## [0.6.0] - 2016-02-26
 ### Added

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ libraryDependencies ++= {
     "io.spray"                 %% "spray-util"      % sprayVersion,
     "net.databinder.dispatch"  %% "dispatch-core"   % "0.11.2",
     "org.clapper"              %% "grizzled-slf4j"  % "1.0.2",
-    "org.specs2"               %% "specs2"          % "2.4.13"       % "it,test",
+    "org.specs2"               %% "specs2-core"     % "3.7.2"        % "it,test",
     "org.slf4j"                %  "slf4j-simple"    % "1.7.6"        % "it,test"
   )
 }

--- a/src/it/scala/ClientIntegrationSpec.scala
+++ b/src/it/scala/ClientIntegrationSpec.scala
@@ -1,3 +1,4 @@
+package io.keen.client.scala
 package test
 
 import scala.concurrent.Await
@@ -5,8 +6,6 @@ import scala.concurrent.duration._
 
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
-
-import io.keen.client.scala._
 
 class ClientIntegrationSpec extends Specification with NoTimeConversions {
   // Timeout used for most future awaits, etc. ScalaTest and Akka TestKit both

--- a/src/main/scala/io/keen/client/scala/BatchWriterClient.scala
+++ b/src/main/scala/io/keen/client/scala/BatchWriterClient.scala
@@ -1,0 +1,208 @@
+package io.keen.client.scala
+
+import java.util.concurrent.{ Executors, ScheduledThreadPoolExecutor, TimeUnit }
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import com.typesafe.config.{ Config, ConfigFactory }
+
+object BatchWriterClient {
+  val MinSendIntervalEvents: Long = 100
+  val MaxSendIntervalEvents: Long = 10000
+  val MinSendInterval: FiniteDuration = 60.seconds
+  val MaxSendInterval: FiniteDuration = 1.hour
+}
+
+/**
+ * A BatchWriterClient is a [[Client]] specialized with the capability to write
+ * events to the Keen API in batches per request.
+ *
+ * Each instance creates a threadpool and schedules flush operations on it, which
+ * will make bulk write calls to the Keen IO API for batches of events until the
+ * queue is drained.
+ *
+ * Events are queued for batch submission with [[queueEvent]]; other operations
+ * like [[addEvent]] function as with an ordinary `Client with Writer`—that is,
+ * they are non-blocking but effect discrete API calls per invocation.
+ *
+ * Batch size, flush scheduling, queue bounds, etc. can be tuned via the settings
+ * under the `keen.queue` property tree.
+ *
+ * TODO: explain the difference in behavior if send-interval is zero seconds.
+ *
+ * @param config Client configuration, by default loaded from `application.conf`.
+ */
+class BatchWriterClient(config: Config = ConfigFactory.load())
+    extends Client(config)
+    with Writer {
+
+  import BatchWriterClient._
+
+  /** The number of events sent in a single API call when flushing batches */
+  val batchSize: Integer = settings.batchSize
+
+  /** Timeout for each bulk write API call when flushing batches */
+  val batchTimeout: FiniteDuration = settings.batchTimeout
+
+  /** Threshold of queued events at which flush of batches is triggered */
+  val sendIntervalEvents: Integer = settings.sendIntervalEvents
+
+  /** Time interval at which batches of queued event writes are scheduled to be flushed */
+  val sendInterval: FiniteDuration = settings.sendIntervalDuration
+
+  /** Duration for which client will wait for scheduled batch flushes to complete when shutting down */
+  val shutdownDelay: FiniteDuration = settings.shutdownDelay
+
+  // initialize and configure our local event store queue
+  // FIXME: should be protected, but tests need to be updated; the EventStore
+  // should be an injectable component like HttpAdapter (though the injection
+  // pattern still needs work on that too)
+  val eventStore: EventStore = new RamEventStore
+  eventStore.maxEventsPerCollection = settings.maxEventsPerCollection
+
+  // Schedule sending of queued events.
+  protected val scheduledThreadPool: Option[ScheduledThreadPoolExecutor] = scheduleSendQueuedEvents()
+
+  /**
+   * Queue an event for batched publishing.
+   *
+   * @param collection The collection to which the event will be added.
+   * @param event The event
+   */
+  def queueEvent(collection: String, event: String): Unit = {
+    // bypass min/max intervals for testing
+    // FIXME: There are less kludgey ways to achieve testability here
+    environment match {
+      case Some("test") if Some("test").get matches "(?i)test" =>
+      case _ =>
+        require(
+          sendIntervalEvents == 0 || (sendIntervalEvents >= MinSendIntervalEvents && sendIntervalEvents <= MaxSendIntervalEvents),
+          s"Send events interval must be between $MinSendIntervalEvents and $MaxSendIntervalEvents"
+        )
+    }
+
+    eventStore.store(projectId, collection, event)
+
+    // If we've met a configured event count threshold, flush the queue.
+    if (sendIntervalEvents != 0 && eventStore.size >= sendIntervalEvents) {
+      sendQueuedEvents()
+    }
+  }
+
+  /**
+   * Schedule periodic sending of queued events, on a threadpool.
+   */
+  private def scheduleSendQueuedEvents(): Option[ScheduledThreadPoolExecutor] = {
+    // bypass min/max intervals for testing
+    environment match {
+      case Some("test") if Some("test").get matches "(?i)test" =>
+      case _ =>
+        require(
+          sendInterval.toSeconds == 0 || (sendInterval >= MinSendInterval && sendInterval <= MaxSendInterval),
+          s"Send interval must be between $MinSendInterval and $MaxSendInterval"
+        )
+    }
+
+    // send queued events every n seconds
+    sendInterval.toSeconds match {
+      case n if n <= 0 => None // TODO: document what config value of zero means
+      case _ =>
+        // use a thread pool for our scheduled threads so we can use daemon threads
+        val tp = Executors.newScheduledThreadPool(1, new ClientThreadFactory).asInstanceOf[ScheduledThreadPoolExecutor]
+
+        // schedule sending from our thread pool at a specific interval
+        tp.scheduleWithFixedDelay(new Runnable {
+          def run(): Unit = {
+            try {
+              sendQueuedEvents()
+            } catch {
+              case ex: Throwable =>
+                error("Failed to send queued events")
+                error(s"$ex")
+            }
+          }
+        }, 1, sendInterval.toMillis, TimeUnit.MILLISECONDS)
+
+        Some(tp)
+    }
+  }
+
+  /**
+   * Flush queued events, removing them from the queue as they are successfully sent.
+   */
+  def sendQueuedEvents(): Unit = {
+    val handleMap = eventStore.getHandles(projectId)
+    val handles = ListBuffer.empty[Long]
+    val events = ListBuffer.empty[String]
+
+    // iterate over all of the event handles in the queue, by collection
+    for ((collection, eventHandles) <- handleMap) {
+      // get each event, and its handle, then add it to a buffer so we can group the events
+      // into smaller batches
+      for (handle <- eventHandles) {
+        handles += handle
+        events += eventStore.get(handle)
+      }
+
+      // group handles separately so we can use them to remove events from the queue once they've
+      // been successfully added
+      val handleGroup: List[ListBuffer[Long]] = handles.grouped(batchSize).toList
+
+      // group the events by batch size, then publish them
+      for ((batch, index) <- events.grouped(batchSize).zipWithIndex) {
+        // publish this batch
+        var response = Await.result(
+          addEvents(s"""{"$collection": [${batch.mkString(",")}]}"""),
+          batchTimeout
+        )
+
+        // handle addEvents responses properly
+        response.statusCode match {
+          case 200 | 201 =>
+            info(s"""${response.statusCode} ${response.body} | Sent ${batch.size} queued events""")
+
+            // remove all of the handles for this batch
+            for (handle <- handleGroup(index)) {
+              eventStore.remove(handle)
+            }
+
+            info(s"""Removed ${handleGroup(index).size} events from the queue""")
+
+          // log but DO NOT remove events from queue
+          case _ => error(s"""${response.statusCode} ${response.body} | Failed to send ${batch.size} queued events""")
+        }
+      }
+    }
+  }
+
+  /**
+   * Flush queued events, sending them to Keen IO on a background thread.
+   */
+  def sendQueuedEventsAsync(): Unit = {
+    // use a thread pool for our async thread so we can use daemon threads
+    val tp = Executors.newSingleThreadExecutor(new ClientThreadFactory)
+
+    // send our queued events in a separate thread
+    tp.execute(new Runnable {
+      def run(): Unit = sendQueuedEvents()
+    })
+  }
+
+  /**
+   * Shut down the threadpool for flushing batch writes, before a final flush of
+   * all events remaining in the queue, run on the main thread.
+   */
+  override def shutdown() = {
+    // Shut down the threadpool, if there is one.
+    scheduledThreadPool foreach { pool =>
+      pool.shutdown()
+      val terminated = pool.awaitTermination(shutdownDelay.toMillis, TimeUnit.MILLISECONDS)
+      if (!terminated) { error("Failed to shutdown scheduled thread pool") }
+    }
+
+    sendQueuedEvents() // flush the queue, on the main thread
+    super.shutdown()
+  }
+}

--- a/src/main/scala/io/keen/client/scala/Settings.scala
+++ b/src/main/scala/io/keen/client/scala/Settings.scala
@@ -37,7 +37,7 @@ class Settings(config: Config) {
   val readKey: Option[String]   = config.getOptionalString("keen.optional.read-key")
   val writeKey: Option[String]  = config.getOptionalString("keen.optional.write-key")
 
-  // Writer-specific settings
+  // Batched write settings
   val batchSize: Integer                   = config.getInt("keen.queue.batch.size")
   val batchTimeout: FiniteDuration         = config.getFiniteDuration("keen.queue.batch.timeout")
   val maxEventsPerCollection: Integer      = config.getInt("keen.queue.max-events-per-collection")

--- a/src/test/scala/AttemptCountingEventStoreSpecBase.scala
+++ b/src/test/scala/AttemptCountingEventStoreSpecBase.scala
@@ -1,6 +1,5 @@
+package io.keen.client.scala
 package test
-
-import io.keen.client.scala.AttemptCountingEventStore
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer

--- a/src/test/scala/AttemptCountingEventStoreSpecBase.scala
+++ b/src/test/scala/AttemptCountingEventStoreSpecBase.scala
@@ -38,15 +38,15 @@ abstract class AttemptCountingEventStoreSpecBase extends EventStoreSpecBase {
 
       // get the handle map
       val handleMap: TrieMap[String, ListBuffer[Long]] = attemptCountingStore.getHandles("project1")
-      (handleMap must not beNull)
+      handleMap must not be null
       handleMap.size must beEqualTo(2)
 
       // get the lists of handles
       var handles1: ListBuffer[Long] = handleMap.getOrElse("collection1", null)
-      (handles1 must not beNull)
+      handles1 must not be null
       handles1.size must beEqualTo(1)
       var handles2: ListBuffer[Long] = handleMap.getOrElse("collection2", null)
-      (handles2 must not beNull)
+      handles2 must not be null
       handles2.size must beEqualTo(1)
 
       // validate the actual events

--- a/src/test/scala/BatchWriterClientSpec.scala
+++ b/src/test/scala/BatchWriterClientSpec.scala
@@ -8,7 +8,9 @@ import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigFactory
 
-class BatchWriterClientSpec extends ClientSpec {
+// TODO: Factor the base Client specs so that they can all be included here, with
+// an injected BatchWriterClient
+class BatchWriterClientSpec extends ClientSpecification {
   // generates n test events
   def generateTestEvents(n: Integer): ListBuffer[String] = {
     val events = ListBuffer.empty[String]

--- a/src/test/scala/BatchWriterClientSpec.scala
+++ b/src/test/scala/BatchWriterClientSpec.scala
@@ -92,6 +92,7 @@ class BatchWriterClientSpec extends ClientSpecification {
 
       // validate that the store is now empty as a result of sendQueuedEvents being automatically
       // triggered with the queueing of the 100th event
+      Thread.sleep(300.millis.toMillis) // flush is async, wait for a beat
       handleMap = store.getHandles(projectId)
       handleMap.size must beEqualTo(0)
     }
@@ -108,7 +109,7 @@ class BatchWriterClientSpec extends ClientSpecification {
       // sleep until the set interval is reached
       // FIXME: This is basically an integration test, and slow. We could test this
       // with a mock that verifies sendQueuedEvents is called after shorter duration.
-      // It's brittle too, use test framework time dilation features.
+      // It's brittle too, use specs2 timeFactor if needed.
       Thread.sleep((client.settings.sendIntervalDuration + 100.millis).toMillis)
 
       // validate that the store is now empty as a result of sendQueuedEvents being automatically

--- a/src/test/scala/BatchWriterClientSpec.scala
+++ b/src/test/scala/BatchWriterClientSpec.scala
@@ -1,0 +1,208 @@
+package io.keen.client.scala
+package test
+
+import scala.collection.concurrent.TrieMap
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+class BatchWriterClientSpec extends ClientSpec {
+  // generates n test events
+  def generateTestEvents(n: Integer): ListBuffer[String] = {
+    val events = ListBuffer.empty[String]
+    for (i <- 1 to n) {
+      events += s"""{"param$i":"value$i"}"""
+    }
+    events
+  }
+
+  "BatchWriterClient with interval-based queueing" should {
+    val queueConfig = ConfigFactory.parseMap(
+      Map(
+        "keen.optional.environment" -> "test",
+        "keen.queue.batch.size" -> 5,
+        "keen.queue.batch.timeout" -> "5 seconds",
+        "keen.queue.max-events-per-collection" -> 250,
+        "keen.queue.send-interval.events" -> 100,
+        "keen.queue.send-interval.duration" -> "2 seconds",
+        "keen.queue.shutdown-delay" -> "0s"
+      )
+    ).withFallback(dummyConfig)
+
+    val client = new BatchWriterClient(config = queueConfig) {
+      override val httpAdapter = new OkHttpAdapter
+    }
+
+    val collection = "foo"
+    val projectId = client.settings.projectId
+
+    var handleMap = TrieMap.empty[String, ListBuffer[Long]]
+    val store = client.eventStore
+    var testEvents = ListBuffer.empty[String]
+
+    "send queued events" in {
+      testEvents = generateTestEvents(5)
+      testEvents.foreach { event => client.queueEvent(collection, event) }
+
+      // verify that the expected number of events are in the store
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(1)
+      handleMap.getOrElse(collection, null).size must beEqualTo(5)
+
+      // send the queued events
+      client.sendQueuedEvents()
+
+      // validate that the store is now empty
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(0)
+
+      // try sending events again, nothing should happen because the queue is empty
+      client.sendQueuedEvents()
+
+      // the store should still be empty
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(0)
+    }
+
+    "automatically send queued events when queue reaches keen.queue.send-interval.events" in {
+      testEvents = generateTestEvents(100)
+
+      // queue the first 50 events
+      for (i <- 0 to 49) {
+        client.queueEvent(collection, testEvents(i))
+      }
+
+      // verify that the expected number of events are in the store
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(1)
+      handleMap.getOrElse(collection, null).size must beEqualTo(50)
+
+      // add the final 50 events
+      for (i <- 50 to 99) {
+        client.queueEvent(collection, testEvents(i))
+      }
+
+      // validate that the store is now empty as a result of sendQueuedEvents being automatically
+      // triggered with the queueing of the 100th event
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(0)
+    }
+
+    "automatically send queued events every keen.queue.send-interval.duration" in {
+      testEvents = generateTestEvents(5)
+      testEvents.foreach { event => client.queueEvent(collection, event) }
+
+      // verify that the expected number of events are in the store
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(1)
+      handleMap.getOrElse(collection, null).size must beEqualTo(5)
+
+      // sleep until the set interval is reached
+      // FIXME: This is basically an integration test, and slow. We could test this
+      // with a mock that verifies sendQueuedEvents is called after shorter duration.
+      // It's brittle too, use test framework time dilation features.
+      Thread.sleep((client.settings.sendIntervalDuration + 100.millis).toMillis)
+
+      // validate that the store is now empty as a result of sendQueuedEvents being automatically
+      // triggered with the queueing of the 100th event
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(0)
+    }
+
+    "send queued events on shutdown" in {
+      testEvents = generateTestEvents(5)
+      testEvents.foreach { event => client.queueEvent(collection, event) }
+
+      // verify that the expected number of events are in the store
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(1)
+      handleMap.getOrElse(collection, null).size must beEqualTo(5)
+
+      // send the queued events
+      client.shutdown()
+
+      // validate that the store is now empty
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(0)
+    }
+  }
+
+  "BatchWriterClient with simple queueing" should {
+    val queueConfig = ConfigFactory.parseMap(
+      Map(
+        "keen.optional.environment" -> "test",
+        "keen.queue.batch.size" -> 5,
+        "keen.queue.batch.timeout" -> "5 seconds",
+        "keen.queue.max-events-per-collection" -> 250,
+        "keen.queue.send-interval.events" -> 0,
+        "keen.queue.send-interval.duration" -> "0s",
+        "keen.queue.shutdown-delay" -> "0s"
+      )
+    ).withFallback(dummyConfig)
+
+    val client = new BatchWriterClient(config = queueConfig) {
+      override val httpAdapter = new OkHttpAdapter
+    }
+
+    val collection = "foo"
+    val projectId = client.settings.projectId
+
+    var handleMap = TrieMap.empty[String, ListBuffer[Long]]
+    val store = client.eventStore
+    var testEvents = ListBuffer.empty[String]
+
+    "not exceed keen.queue.max-events-per-collection" in {
+      testEvents = generateTestEvents(500)
+      testEvents.foreach { event => client.queueEvent(collection, event) }
+
+      // verify that the expected number of events are in the store
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(1)
+      handleMap.getOrElse(collection, null).size must beEqualTo(store.maxEventsPerCollection)
+
+      // shutdown the client
+      client.shutdown()
+
+      // validate that the store is now empty
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(0)
+    }
+  }
+
+  "BatchWriterClient on 500 errors" should {
+    val client = new BatchWriterClient(config = dummyConfig) {
+      override val httpAdapter = new FiveHundredHttpAdapter()
+    }
+
+    "send queued events with server failure" in {
+      val projectId = client.settings.projectId
+      val collection = "foo"
+      val testEvents = generateTestEvents(5)
+
+      // queue the events
+      for (event <- testEvents) {
+        client.queueEvent(collection, event)
+      }
+
+      // verify that the expected number of events are in the store
+      val store = client.eventStore
+      var handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(1)
+      handleMap.getOrElse(collection, null).size must beEqualTo(5)
+
+      // send the queued events
+      client.sendQueuedEvents()
+
+      // validate that the store still contains all of the queued events
+      handleMap = store.getHandles(projectId)
+      handleMap.size must beEqualTo(1)
+      handleMap.getOrElse(collection, null).size must beEqualTo(5)
+
+      // shutdown the client
+      client.shutdown()
+      true must beEqualTo(true)
+    }
+  }
+}

--- a/src/test/scala/BatchWriterClientSpec.scala
+++ b/src/test/scala/BatchWriterClientSpec.scala
@@ -6,11 +6,30 @@ import scala.collection.JavaConversions._
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ Config, ConfigFactory }
 
 // TODO: Factor the base Client specs so that they can all be included here, with
 // an injected BatchWriterClient
 class BatchWriterClientSpec extends ClientSpecification {
+  // Examples each run in a fresh class instance, with its own copies of the
+  // below mutable test vars, a new client & store, etc.
+  isolated
+
+  val collection = "foo"
+  var queueConfig: Config = _
+  var testEvents: ListBuffer[String] = _
+  var handleMap: TrieMap[String, ListBuffer[Long]] = _
+
+  // Late-bind the client for varying queueConfig
+  lazy val client = new BatchWriterClient(config = queueConfig) {
+    override val httpAdapter = new OkHttpAdapter
+  }
+
+  lazy val projectId = client.settings.projectId
+  lazy val store = client.eventStore
+
+  def queueForTestCollection(event: String) = client.queueEvent(collection, event)
+
   // generates n test events
   def generateTestEvents(n: Integer): ListBuffer[String] = {
     val events = ListBuffer.empty[String]
@@ -20,11 +39,8 @@ class BatchWriterClientSpec extends ClientSpecification {
     events
   }
 
-  // TODO: This suite should clear the eventStore between tests, not do this
-  sequential
-
   "BatchWriterClient with interval-based queueing" should {
-    val queueConfig = ConfigFactory.parseMap(
+    queueConfig = ConfigFactory.parseMap(
       Map(
         "keen.optional.environment" -> "test",
         "keen.queue.batch.size" -> 5,
@@ -36,25 +52,14 @@ class BatchWriterClientSpec extends ClientSpecification {
       )
     ).withFallback(dummyConfig)
 
-    val client = new BatchWriterClient(config = queueConfig) {
-      override val httpAdapter = new OkHttpAdapter
-    }
-
-    val collection = "foo"
-    val projectId = client.settings.projectId
-
-    var handleMap = TrieMap.empty[String, ListBuffer[Long]]
-    val store = client.eventStore
-    var testEvents = ListBuffer.empty[String]
-
     "send queued events" in {
       testEvents = generateTestEvents(5)
-      testEvents.foreach { event => client.queueEvent(collection, event) }
+      testEvents foreach (queueForTestCollection)
 
       // verify that the expected number of events are in the store
       handleMap = store.getHandles(projectId)
       handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(5)
+      handleMap(collection).size must beEqualTo(5)
 
       // send the queued events
       client.sendQueuedEvents()
@@ -75,19 +80,15 @@ class BatchWriterClientSpec extends ClientSpecification {
       testEvents = generateTestEvents(100)
 
       // queue the first 50 events
-      for (i <- 0 to 49) {
-        client.queueEvent(collection, testEvents(i))
-      }
+      testEvents take 50 foreach (queueForTestCollection)
 
       // verify that the expected number of events are in the store
       handleMap = store.getHandles(projectId)
       handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(50)
+      handleMap(collection).size must beEqualTo(50)
 
       // add the final 50 events
-      for (i <- 50 to 99) {
-        client.queueEvent(collection, testEvents(i))
-      }
+      testEvents drop 50 foreach (queueForTestCollection)
 
       // validate that the store is now empty as a result of sendQueuedEvents being automatically
       // triggered with the queueing of the 100th event
@@ -97,12 +98,12 @@ class BatchWriterClientSpec extends ClientSpecification {
 
     "automatically send queued events every keen.queue.send-interval.duration" in {
       testEvents = generateTestEvents(5)
-      testEvents.foreach { event => client.queueEvent(collection, event) }
+      testEvents foreach (queueForTestCollection)
 
       // verify that the expected number of events are in the store
       handleMap = store.getHandles(projectId)
       handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(5)
+      handleMap(collection).size must beEqualTo(5)
 
       // sleep until the set interval is reached
       // FIXME: This is basically an integration test, and slow. We could test this
@@ -118,12 +119,12 @@ class BatchWriterClientSpec extends ClientSpecification {
 
     "send queued events on shutdown" in {
       testEvents = generateTestEvents(5)
-      testEvents.foreach { event => client.queueEvent(collection, event) }
+      testEvents foreach (queueForTestCollection)
 
       // verify that the expected number of events are in the store
       handleMap = store.getHandles(projectId)
       handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(5)
+      handleMap(collection).size must beEqualTo(5)
 
       // send the queued events
       client.shutdown()
@@ -135,7 +136,7 @@ class BatchWriterClientSpec extends ClientSpecification {
   }
 
   "BatchWriterClient with simple queueing" should {
-    val queueConfig = ConfigFactory.parseMap(
+    queueConfig = ConfigFactory.parseMap(
       Map(
         "keen.optional.environment" -> "test",
         "keen.queue.batch.size" -> 5,
@@ -147,25 +148,14 @@ class BatchWriterClientSpec extends ClientSpecification {
       )
     ).withFallback(dummyConfig)
 
-    val client = new BatchWriterClient(config = queueConfig) {
-      override val httpAdapter = new OkHttpAdapter
-    }
-
-    val collection = "foo"
-    val projectId = client.settings.projectId
-
-    var handleMap = TrieMap.empty[String, ListBuffer[Long]]
-    val store = client.eventStore
-    var testEvents = ListBuffer.empty[String]
-
     "not exceed keen.queue.max-events-per-collection" in {
       testEvents = generateTestEvents(500)
-      testEvents.foreach { event => client.queueEvent(collection, event) }
+      testEvents foreach (queueForTestCollection)
 
       // verify that the expected number of events are in the store
       handleMap = store.getHandles(projectId)
       handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(store.maxEventsPerCollection)
+      handleMap(collection).size must beEqualTo(store.maxEventsPerCollection)
 
       // shutdown the client
       client.shutdown()
@@ -182,20 +172,13 @@ class BatchWriterClientSpec extends ClientSpecification {
     }
 
     "send queued events with server failure" in {
-      val projectId = client.settings.projectId
-      val collection = "foo"
-      val testEvents = generateTestEvents(5)
-
-      // queue the events
-      for (event <- testEvents) {
-        client.queueEvent(collection, event)
-      }
+      testEvents = generateTestEvents(5)
+      testEvents foreach (queueForTestCollection)
 
       // verify that the expected number of events are in the store
-      val store = client.eventStore
-      var handleMap = store.getHandles(projectId)
+      handleMap = store.getHandles(projectId)
       handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(5)
+      handleMap(collection).size must beEqualTo(5)
 
       // send the queued events
       client.sendQueuedEvents()
@@ -203,11 +186,10 @@ class BatchWriterClientSpec extends ClientSpecification {
       // validate that the store still contains all of the queued events
       handleMap = store.getHandles(projectId)
       handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(5)
+      handleMap(collection).size must beEqualTo(5)
 
       // shutdown the client
-      client.shutdown()
-      true must beEqualTo(true)
+      client.shutdown() must not(throwA[Exception])
     }
   }
 }

--- a/src/test/scala/BatchWriterClientSpec.scala
+++ b/src/test/scala/BatchWriterClientSpec.scala
@@ -20,6 +20,9 @@ class BatchWriterClientSpec extends ClientSpecification {
     events
   }
 
+  // TODO: This suite should clear the eventStore between tests, not do this
+  sequential
+
   "BatchWriterClient with interval-based queueing" should {
     val queueConfig = ConfigFactory.parseMap(
       Map(

--- a/src/test/scala/BatchWriterClientSpec.scala
+++ b/src/test/scala/BatchWriterClientSpec.scala
@@ -107,7 +107,7 @@ class BatchWriterClientSpec extends ClientSpecification {
       handleMap(collection).size must beEqualTo(5)
 
       // sleep until the set interval is reached
-      // FIXME: This is basically an integration test, and slow. We could test this
+      // TODO: This is basically an integration test, and slow. We could test this
       // with a mock that verifies sendQueuedEvents is called after shorter duration.
       // It's brittle too, use specs2 timeFactor if needed.
       Thread.sleep((client.settings.sendIntervalDuration + 100.millis).toMillis)

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -11,11 +11,10 @@ import akka.actor.ActorSystem
 import akka.pattern.AskTimeoutException
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 import spray.http.Uri
 import spray.http.Uri._
 
-class ClientSpec extends Specification with NoTimeConversions {
+class ClientSpec extends Specification {
   // Timeout used for most future awaits, etc. With unit tests/mocking this
   // shouldn't normally need to be long.
   val timeout = 1.second

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -30,15 +30,9 @@ trait ClientSpecification extends Specification {
       params: Map[String, Option[String]] = Map.empty
     ): Future[Response] = {
 
-      // We have a map of str,opt[str] and we need to convert it to
-      val filteredParams = params.filter(
-        // Filter out keys that are None
-        _._2.isDefined
-      ).map(
-        // Convert the remaining tuples to str,str
-        param => (param._1 -> param._2.get)
-      )
-      // Make a Uri
+      // Query.apply won't accept the Option wrapper in our param values
+      val filteredParams = params.collect { case (key, Some(value)) => (key, value) }.toMap
+
       val finalUrl = Uri(
         scheme = scheme,
         authority = Authority(host = Host(authority)),

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -14,11 +14,8 @@ import org.specs2.mutable.Specification
 import spray.http.Uri
 import spray.http.Uri._
 
-class ClientSpec extends Specification {
-  // Timeout used for most future awaits, etc. With unit tests/mocking this
-  // shouldn't normally need to be long.
-  val timeout = 1.second
-
+/** Fakes and configuration fixtures for Client specs */
+trait ClientSpecification extends Specification {
   class OkHttpAdapter extends HttpAdapter {
     var lastUrl: Option[String] = None
     var lastKey: Option[String] = None
@@ -101,6 +98,12 @@ class ClientSpec extends Specification {
       "keen.optional.write-key" -> "writeKey"
     )
   ).withFallback(defaultConfig)
+}
+
+class ClientSpec extends ClientSpecification {
+  // Timeout used for most future awaits, etc. With unit tests/mocking this
+  // shouldn't normally need to be long.
+  val timeout = 1.second
 
   // Sequential because it's less work to share the client instance
   // TODO: set up separate read-only client, writer client, etc. instead of

--- a/src/test/scala/ClientSpec.scala
+++ b/src/test/scala/ClientSpec.scala
@@ -1,8 +1,7 @@
+package io.keen.client.scala
 package test
 
-import scala.collection.concurrent.TrieMap
 import scala.collection.JavaConversions._
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ Await, Future, TimeoutException }
@@ -15,8 +14,6 @@ import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 import spray.http.Uri
 import spray.http.Uri._
-
-import io.keen.client.scala._
 
 class ClientSpec extends Specification with NoTimeConversions {
   // Timeout used for most future awaits, etc. With unit tests/mocking this
@@ -105,15 +102,6 @@ class ClientSpec extends Specification with NoTimeConversions {
       "keen.optional.write-key" -> "writeKey"
     )
   ).withFallback(defaultConfig)
-
-  // generates n test events
-  def generateTestEvents(n: Integer): ListBuffer[String] = {
-    val events = ListBuffer.empty[String]
-    for (i <- 1 to n) {
-      events += s"""{"param$i":"value$i"}"""
-    }
-    events
-  }
 
   // Sequential because it's less work to share the client instance
   // TODO: set up separate read-only client, writer client, etc. instead of
@@ -282,156 +270,6 @@ class ClientSpec extends Specification with NoTimeConversions {
     }
   }
 
-  "Client with interval-based queueing enabled" should {
-    val queueConfig = ConfigFactory.parseMap(
-      Map(
-        "keen.optional.environment" -> "test",
-        "keen.queue.batch.size" -> 5,
-        "keen.queue.batch.timeout" -> "5 seconds",
-        "keen.queue.max-events-per-collection" -> 250,
-        "keen.queue.send-interval.events" -> 100,
-        "keen.queue.send-interval.duration" -> "2 seconds",
-        "keen.queue.shutdown-delay" -> "0s"
-      )
-    ).withFallback(dummyConfig)
-
-    val client = new Client(config = queueConfig) with Master {
-      override val httpAdapter = new OkHttpAdapter
-    }
-
-    val collection = "foo"
-    val projectId = client.settings.projectId
-
-    var handleMap = TrieMap.empty[String, ListBuffer[Long]]
-    val store = client.eventStore
-    var testEvents = ListBuffer.empty[String]
-
-    "send queued events" in {
-      testEvents = generateTestEvents(5)
-      testEvents.foreach { event => client.queueEvent(collection, event) }
-
-      // verify that the expected number of events are in the store
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(5)
-
-      // send the queued events
-      client.sendQueuedEvents()
-
-      // validate that the store is now empty
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(0)
-
-      // try sending events again, nothing should happen because the queue is empty
-      client.sendQueuedEvents()
-
-      // the store should still be empty
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(0)
-    }
-
-    "automatically send queued events when queue reaches keen.queue.send-interval.events" in {
-      testEvents = generateTestEvents(100)
-
-      // queue the first 50 events
-      for (i <- 0 to 49) {
-        client.queueEvent(collection, testEvents(i))
-      }
-
-      // verify that the expected number of events are in the store
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(50)
-
-      // add the final 50 events
-      for (i <- 50 to 99) {
-        client.queueEvent(collection, testEvents(i))
-      }
-
-      // validate that the store is now empty as a result of sendQueuedEvents being automatically
-      // triggered with the queueing of the 100th event
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(0)
-    }
-
-    "automatically send queued events every keen.queue.send-interval.duration" in {
-      testEvents = generateTestEvents(5)
-      testEvents.foreach { event => client.queueEvent(collection, event) }
-
-      // verify that the expected number of events are in the store
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(5)
-
-      // sleep until the set interval is reached
-      Thread.sleep((client.settings.sendIntervalDuration + 100.millis).toMillis)
-
-      // validate that the store is now empty as a result of sendQueuedEvents being automatically
-      // triggered with the queueing of the 100th event
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(0)
-    }
-
-    "send queued events on shutdown" in {
-      testEvents = generateTestEvents(5)
-      testEvents.foreach { event => client.queueEvent(collection, event) }
-
-      // verify that the expected number of events are in the store
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(5)
-
-      // send the queued events
-      client.shutdown()
-
-      // validate that the store is now empty
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(0)
-    }
-  }
-
-  "Client with simple queueing enabled" should {
-    val queueConfig = ConfigFactory.parseMap(
-      Map(
-        "keen.optional.environment" -> "test",
-        "keen.queue.batch.size" -> 5,
-        "keen.queue.batch.timeout" -> "5 seconds",
-        "keen.queue.max-events-per-collection" -> 250,
-        "keen.queue.send-interval.events" -> 0,
-        "keen.queue.send-interval.duration" -> "0s",
-        "keen.queue.shutdown-delay" -> "0s"
-      )
-    ).withFallback(dummyConfig)
-
-    val client = new Client(config = queueConfig) with Master {
-      override val httpAdapter = new OkHttpAdapter
-    }
-
-    val collection = "foo"
-    val projectId = client.settings.projectId
-
-    var handleMap = TrieMap.empty[String, ListBuffer[Long]]
-    val store = client.eventStore
-    var testEvents = ListBuffer.empty[String]
-
-    "not exceed keen.queue.max-events-per-collection" in {
-      testEvents = generateTestEvents(500)
-      testEvents.foreach { event => client.queueEvent(collection, event) }
-
-      // verify that the expected number of events are in the store
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(store.maxEventsPerCollection)
-
-      // shutdown the client
-      client.shutdown()
-
-      // validate that the store is now empty
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(0)
-    }
-  }
-
   "Client with Spray HttpAdapter" should {
     lazy val externalSystem = ActorSystem("keen-test-user-supplied")
 
@@ -474,35 +312,6 @@ class ClientSpec extends Specification with NoTimeConversions {
     "handle 500" in {
       val res = Await.result(client.getProjects, timeout)
       res.statusCode must beEqualTo(500)
-    }
-
-    "send queued events with server failure" in {
-      val projectId = client.settings.projectId
-      val collection = "foo"
-      val testEvents = generateTestEvents(5)
-
-      // queue the events
-      for (event <- testEvents) {
-        client.queueEvent(collection, event)
-      }
-
-      // verify that the expected number of events are in the store
-      val store = client.eventStore
-      var handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(5)
-
-      // send the queued events
-      client.sendQueuedEvents()
-
-      // validate that the store still contains all of the queued events
-      handleMap = store.getHandles(projectId)
-      handleMap.size must beEqualTo(1)
-      handleMap.getOrElse(collection, null).size must beEqualTo(5)
-
-      // shutdown the client
-      client.shutdown()
-      true must beEqualTo(true)
     }
   }
 

--- a/src/test/scala/EventStoreSpecBase.scala
+++ b/src/test/scala/EventStoreSpecBase.scala
@@ -1,6 +1,5 @@
+package io.keen.client.scala
 package test
-
-import io.keen.client.scala.EventStore
 
 import java.io.IOException
 

--- a/src/test/scala/EventStoreSpecBase.scala
+++ b/src/test/scala/EventStoreSpecBase.scala
@@ -1,29 +1,17 @@
 package io.keen.client.scala
 package test
 
-import java.io.IOException
-
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 
 import org.specs2.mutable.{ BeforeAfter, Specification }
-import org.specs2.specification.{ Step, Fragments }
+import org.specs2.specification.BeforeAfterAll
 
-trait BeforeAllAfterAll extends Specification {
-  override def map(fragments: => Fragments) =
-    Step(beforeAll()) ^ fragments ^ Step(afterAll())
-
-  protected def beforeAll(): Unit
-  protected def afterAll(): Unit
-}
-
-abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
-
-  @throws(classOf[IOException])
-  def buildStore(): EventStore
-
+abstract class EventStoreSpecBase extends Specification with BeforeAfterAll {
   var store: EventStore = _
   val testEvents: ListBuffer[String] = new ListBuffer[String]
+
+  def buildStore(): EventStore
 
   def beforeAll() = {
     store = buildStore() // initialize our store
@@ -77,15 +65,15 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
 
       // get the handle map
       val handleMap: TrieMap[String, ListBuffer[Long]] = store.getHandles("project1")
-      (handleMap must not beNull)
+      handleMap must not be null
       handleMap.size must beEqualTo(2)
 
       // get the lists of handles
       var handles1: ListBuffer[Long] = handleMap.getOrElse("collection1", null)
-      (handles1 must not beNull)
+      handles1 must not be null
       handles1.size must beEqualTo(1)
       var handles2: ListBuffer[Long] = handleMap.getOrElse("collection2", null)
-      (handles2 must not beNull)
+      handles2 must not be null
       handles2.size must beEqualTo(1)
 
       // validate the actual events
@@ -95,7 +83,7 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
 
     "get handles with no events" in new EventStoreSetupTeardown {
       val handleMap: TrieMap[String, ListBuffer[Long]] = store.getHandles("project1")
-      (handleMap must not beNull)
+      handleMap must not be null
       handleMap.size must beEqualTo(0)
     }
 
@@ -108,14 +96,14 @@ abstract class EventStoreSpecBase extends Specification with BeforeAllAfterAll {
 
       // get and validate the handle map for project 1
       var handleMap: TrieMap[String, ListBuffer[Long]] = store.getHandles("project1")
-      (handleMap must not beNull)
+      handleMap must not be null
       handleMap.size must beEqualTo(2)
       handleMap.getOrElse("collection1", null).size must beEqualTo(1)
       handleMap.getOrElse("collection2", null).size must beEqualTo(1)
 
       // get and validate the handle map for project 2
       handleMap = store.getHandles("project2")
-      (handleMap must not beNull)
+      handleMap must not be null
       handleMap.size must beEqualTo(1)
       handleMap.getOrElse("collection3", null).size must beEqualTo(2)
     }

--- a/src/test/scala/RamEventStoreSpec.scala
+++ b/src/test/scala/RamEventStoreSpec.scala
@@ -1,7 +1,5 @@
+package io.keen.client.scala
 package test
-
-import io.keen.client.scala.EventStore
-import io.keen.client.scala.RamEventStore
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer

--- a/src/test/scala/RamEventStoreSpec.scala
+++ b/src/test/scala/RamEventStoreSpec.scala
@@ -5,9 +5,7 @@ import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 
 class RamEventStoreSpec extends AttemptCountingEventStoreSpecBase {
-  override def buildStore(): EventStore = {
-    new RamEventStore
-  }
+  override def buildStore(): EventStore = new RamEventStore
 
   sequential
 
@@ -23,18 +21,18 @@ class RamEventStoreSpec extends AttemptCountingEventStoreSpecBase {
 
       // get the handle map
       val handleMap: TrieMap[String, ListBuffer[Long]] = ramStore.getHandles("project1")
-      (handleMap must not beNull)
+      handleMap must not be null
 
       // get the lists of handles
       val handles: ListBuffer[Long] = handleMap.getOrElse("collection1", null)
-      (handles must not beNull)
+      handles must not be null
       handles.size must beEqualTo(3)
 
       // get the events
       val retrievedEvents: ListBuffer[String] = new ListBuffer[String]()
       for (handle <- handles) {
         val retrievedEvent: String = ramStore.get(handle)
-        (retrievedEvent must not beNull)
+        retrievedEvent must not be null
         retrievedEvents += retrievedEvent
       }
 


### PR DESCRIPTION
Okay, this builds and passes tests as-is, but I also have some thoughts/questions remaining from #38 and since that's merged, I'll raise them with inline comments on the code that reappears here. If the scope gets stretched too far by discussion of these, we can defer some to later PRs.

Here's my reasoning behind the change already presented here:

I first raised an eyebrow [at why `super` wasn't called][1] in the `shutdown()` method added to `Writer` in #38 to terminate threadpools. It can't, because `Writer` is not a subclass of `Client`, it's a trait with a self-type. This lead me to think further:

`Writer` does not have an “is a” relationship to `Client`. Multiple `AccessLevel`s like `Writer` can be mixed into a `Client`, and the `AccessLevel` abstraction is about *what* API calls a `Client` can make, not *how* it makes them (e.g. with delayed batching).

Thus I felt that batched write functionality really belongs in a subclass of `Client with Writer` instead. This design choice seems supported by the facts that:

- The natural `super.shutdown()` call is now possible.
- The “constants” for flush intervals, etc. can now truly be constant in a companion object, not reallocated for every `Client` instance that mixes in `Writer`.
- There is no chance of inadvertently allocating a needless threadpool in `scheduledThreadPool` in case you only intend to use `Writer` with no batched writes—it's a bit obscure, but this could have happened if you twiddled `send-interval.duration` to a nonzero value and then didn't end up using `queueEvent` at all.

Code in the new class is just moved over from the original implementation, plus some additional Scaladoc, and minor trivial refactorings (I should have made those in a subsequent commit, sorry).

[1]: https://github.com/keenlabs/KeenClient-Scala/blob/85d4fdd5c6a0d90fb1d7f3a0e37f9de93777ddcc/src/main/scala/io/keen/client/scala/Client.scala#L583-L584