### PR TITLE
Scaladoc and publishing it

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,6 @@
 # Publishing
 
-We host artifacts for this library on Maven central. [Here are the official docs for that](http://central.sonatype.org/pages/ossrh-guide.html).
+We host artifacts for this library on Maven Central. [Here are the official docs for that](http://central.sonatype.org/pages/ossrh-guide.html).
 
 Those are kinda complicated, so you'll need the following to publish to it:
 
@@ -10,10 +10,17 @@ Those are kinda complicated, so you'll need the following to publish to it:
 
 # Actual Release Process
 
-* Update the CHANGELOG
-* Update the version number
-* Run `sbt +publishSigned`
-* Go to [Sonatype](https://oss.sonatype.org/#stagingRepositories) and "Close" the repo
-* Await the above to finish, fix anything that breaks if it breaks
-* Go to Sonatype again and "Release" the repo
-* It should show up on maven central at some point after that.
+* Update `CHANGELOG.md`
+* Update `version` in `build.sbt`
+* Commit, tag, and push
+* Publish the artifacts:
+    * Run `sbt +publishSigned`
+    * Visit [Sonatype](https://oss.sonatype.org/#stagingRepositories) and "Close" the repo
+    * Await the above to finish, fix anything that breaks if it breaks
+    * Go to Sonatype again and "Release" the repo
+    * It should show up on Maven Central at some point after that.
+* Publish new Scaladoc API documentation:
+
+        $ sbt ghpagesPushSite
+
+  If you're feeling prudent, you can run `sbt previewSite` first to take a look.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # KeenClient-Scala
 
 [![Build Status]](https://travis-ci.org/keenlabs/KeenClient-Scala)
+[![Maven Central Badge]](https://maven-badges.herokuapp.com/maven-central/io.keen/keenclient-scala_2.11)
+[![Scaladoc Badge]](https://keenlabs.github.io/KeenClient-Scala/)
 
 ---
 
@@ -101,7 +103,7 @@ can set env vars for app processes with ease. On Heroku you'll be right at home.
 ```scala
 import io.keen.client.scala.{ Client, Writer }
 
-// Assumes you've configured a write key as explained in Configuration below
+// Assumes you've configured a write key as explained in Configuration above
 val keen = new Client with Writer
 
 // Publish an event!
@@ -243,6 +245,8 @@ that you didn't expect!**
 
 
 [Build Status]: https://travis-ci.org/keenlabs/KeenClient-Scala.svg?branch=master
+[Maven Central Badge]: https://maven-badges.herokuapp.com/maven-central/io.keen/keenclient-scala_2.11/badge.svg
+[Scaladoc Badge]: https://img.shields.io/badge/scaladoc-latest-lightgrey.svg
 [Keen IO]: http://keen.io/
 [Semantic Versioning]: http://semver.org/
 [the changelog]: https://github.com/keenlabs/KeenClient-Scala/blob/master/CHANGELOG.md

--- a/build.sbt
+++ b/build.sbt
@@ -73,12 +73,25 @@ configs(IntegrationTest)
  * the gh-pages branch including old versions of the API docs.
  */
 autoAPIMappings := true
-scalacOptions in (Compile, doc) ++= Seq(
-  "-doc-title", "Keen IO API Client",
-  "-doc-version", version.value,
-  // "-doc-root-content", baseDirectory.value + "/README.md",  // If only Scaladoc supported Markdown...
-  "-groups"
-)
+scalacOptions in (Compile, doc) <++= (version, scmInfo, baseDirectory in ThisBuild) map {
+  case (version, Some(scm), basedir) =>
+    val sourceTemplate =
+      if (version.endsWith("SNAPSHOT"))
+        s"${scm.browseUrl}/tree/master€{FILE_PATH}.scala"
+      else
+        s"${scm.browseUrl}/tree/v${version}€{FILE_PATH}.scala"
+
+    Seq(
+      "-doc-title", "Keen IO API Client",
+      "-doc-version", version,
+      // "-doc-root-content", baseDirectory.value + "/README.md",  // If only Scaladoc supported Markdown...
+      "-sourcepath", basedir.getAbsolutePath,
+      "-doc-source-url", sourceTemplate,
+      "-groups"
+    )
+
+  case _ => Seq.empty
+}
 
 enablePlugins(SiteScaladocPlugin)
 siteSubdirName in SiteScaladoc := s"api/${version.value}"

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,9 @@ initialCommands in console := "import io.keen.client.scala._"
 // ...but skip it in case we've broken the build and want the REPL to find out why!
 initialCommands in consoleQuick := ""
 
+// We already pull in sbt-git for sbt-ghpages, so hey why not.
+enablePlugins(GitBranchPrompt)
+
 // SBT support for Maven-style integration tests (src/it)
 Defaults.itSettings
 configs(IntegrationTest)
@@ -52,7 +55,22 @@ configs(IntegrationTest)
  * `target/site/api/$version` and a small shim to redirect from the site root
  * directly to the API docs, since there is no other site to display.
  *
- * The `makeSite` and `previewSite` tasks are salient.
+ * Salient tasks that this adds:
+ *
+ *   - `makeSite`        - Build the site locally.
+ *   - `previewSite`     - Serve site and open in browser.
+ *   - `ghpagesPushSite` - Do gh-pages branch dance, commit new docs, and push.
+ *                         This is done in a sandbox checkout of the repo, so it
+ *                         won't clobber anything dirty in your working dir.
+ *
+ * The latter '''should''' retain old versions of the API docs so that links to
+ * them don't break, but this is currently broken in sbt-ghpages--subscribe here
+ * to track fixes: https://github.com/sbt/sbt-ghpages/issues/10
+ *
+ * Once that's fixed, keep the below doc: :-)
+ *
+ * Please do not use the `ghpagesCleanSite` task, it wipes out the contents of
+ * the gh-pages branch including old versions of the API docs.
  */
 autoAPIMappings := true
 scalacOptions in (Compile, doc) ++= Seq(
@@ -68,6 +86,10 @@ siteSubdirName in SiteScaladoc := s"api/${version.value}"
 // Builds static files in src/site-preprocess with variable substitution.
 enablePlugins(PreprocessPlugin)
 preprocessVars := Map("VERSION" -> version.value)
+
+// Enables easy publishing to project's gh-pages.
+ghpages.settings
+git.remoteRepo := "git@github.com:keenlabs/KeenClient-Scala.git"
 
 // Source Formatting
 import com.typesafe.sbt.SbtScalariform

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= {
   val sprayVersion = "1.3.2"
   Seq(
     "com.typesafe.akka"        %% "akka-actor"      % "2.3.6",
-    "com.typesafe"             %  "config"          % "1.2.1",
+    "com.typesafe"             %  "config"          % "1.2.1",       // 1.3+ is Java 8-only
     "io.spray"                 %% "spray-can"       % sprayVersion,
     "io.spray"                 %% "spray-http"      % sprayVersion,
     "io.spray"                 %% "spray-httpx"     % sprayVersion,
@@ -44,6 +44,30 @@ initialCommands in consoleQuick := ""
 // SBT support for Maven-style integration tests (src/it)
 Defaults.itSettings
 configs(IntegrationTest)
+
+/**
+ * Scaladoc Generation
+ *
+ * This sets up the sbt-site plugin to generate API documentation in
+ * `target/site/api/$version` and a small shim to redirect from the site root
+ * directly to the API docs, since there is no other site to display.
+ *
+ * The `makeSite` and `previewSite` tasks are salient.
+ */
+autoAPIMappings := true
+scalacOptions in (Compile, doc) ++= Seq(
+  "-doc-title", "Keen IO API Client",
+  "-doc-version", version.value,
+  // "-doc-root-content", baseDirectory.value + "/README.md",  // If only Scaladoc supported Markdown...
+  "-groups"
+)
+
+enablePlugins(SiteScaladocPlugin)
+siteSubdirName in SiteScaladoc := s"api/${version.value}"
+
+// Builds static files in src/site-preprocess with variable substitution.
+enablePlugins(PreprocessPlugin)
+preprocessVars := Map("VERSION" -> version.value)
 
 // Source Formatting
 import com.typesafe.sbt.SbtScalariform

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,5 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0-RC3")
 
+resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,6 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
-
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
-
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0-RC3")
 

--- a/publishing.sbt
+++ b/publishing.sbt
@@ -38,6 +38,9 @@ scmInfo := Some(
   )
 )
 
+// Allow other projects' Scaladoc to link to ours if they use `autoAPIMappings := true`
+apiURL := Some(url(s"http://keenlabs.github.io/KeenClient-Scala/api/${version.value}/"))
+
 // Central doesn't allow any external repository sources.
 pomIncludeRepository := { _ => false }
 pomExtra :=

--- a/src/main/scala/io/keen/client/scala/BatchWriterClient.scala
+++ b/src/main/scala/io/keen/client/scala/BatchWriterClient.scala
@@ -30,7 +30,7 @@ object BatchWriterClient {
  * Batch size, flush scheduling, queue bounds, etc. can be tuned via the settings
  * under the `keen.queue` property tree.
  *
- * TODO: explain the difference in behavior if send-interval is zero seconds.
+ * @todo Explain the difference in behavior if send-interval is zero seconds.
  *
  * @param config Client configuration, by default loaded from `application.conf`.
  */
@@ -39,19 +39,19 @@ class BatchWriterClient(config: Config = ConfigFactory.load())
 
   import BatchWriterClient._
 
-  /** The number of events sent in a single API call when flushing batches */
+  /** @see [[Settings#batchSize]] */
   val batchSize: Integer = settings.batchSize
 
-  /** Timeout for each bulk write API call when flushing batches */
+  /** @see [[Settings#batchTimeout]] */
   val batchTimeout: FiniteDuration = settings.batchTimeout
 
-  /** Threshold of queued events at which flush of batches is triggered */
+  /** @see [[Settings#sendIntervalEvents]] */
   val sendIntervalEvents: Integer = settings.sendIntervalEvents
 
-  /** Time interval at which batches of queued event writes are scheduled to be flushed */
+  /** @see [[Settings#sendIntervalDuration]] */
   val sendInterval: FiniteDuration = settings.sendIntervalDuration
 
-  /** Duration for which client will wait for scheduled batch flushes to complete when shutting down */
+  /** @see [[Settings#shutdownDelay]] */
   val shutdownDelay: FiniteDuration = settings.shutdownDelay
 
   // initialize and configure our local event store queue

--- a/src/main/scala/io/keen/client/scala/Client.scala
+++ b/src/main/scala/io/keen/client/scala/Client.scala
@@ -140,7 +140,7 @@ trait Reader extends AccessLevel {
    * @param timezone Modifies the timeframe filters for Relative Timeframes to match a specific timezone.
    * @param groupBy The group_by parameter specifies the name of a property by which you would like to group the results. Using this parameter changes the response format. See [[https://keen.io/docs/data-analysis/group-by/ Group By]].
    *
-   * @see [[https://keen.io/docs/api/reference/#average-resource Average Resource]]
+   * @see [[https://keen.io/docs/api/#average Average API Reference]]
    */
   def average(
     collection: String,
@@ -168,7 +168,7 @@ trait Reader extends AccessLevel {
    * @param filters Filters are used to narrow down the events used in an analysis request based on event property values. See [[https://keen.io/docs/data-analysis/filters/ Filters]].
    * @param timeframe A Timeframe specifies the events to use for analysis based on a window of time. If no timeframe is specified, all events will be counted. See [[https://keen.io/docs/data-analysis/timeframe/ Timeframes]].
    *
-   * @see [[https://keen.io/docs/api/reference/#event-resource Event Resource]]
+   * @see [[https://keen.io/docs/api/#count Count API Reference]]
    */
   def count(
     collection: String,
@@ -198,7 +198,7 @@ trait Reader extends AccessLevel {
    * @param timezone Modifies the timeframe filters for Relative Timeframes to match a specific timezone.
    * @param groupBy The group_by parameter specifies the name of a property by which you would like to group the results. Using this parameter changes the response format. See [[https://keen.io/docs/data-analysis/group-by/ Group By]].
    *
-   * @see [[https://keen.io/docs/api/reference/#event-resource Event Resource]]
+   * @see [[https://keen.io/docs/api/#count-unique Count Unique API Reference]]
    */
   def countUnique(
     collection: String,
@@ -220,15 +220,33 @@ trait Reader extends AccessLevel {
     )
 
   /**
-   * @todo Document me!
+   * Creates an extraction request for full-form event data with all property values.
+   *
+   * If the `email` parameter is given, the extraction will be processed asynchronously
+   * and an email will be sent to the specified address when complete. Otherwise events
+   * are returned in a synchronous JSON response with a limit of 100,000 events.
+   *
+   * @param collection The name of the event collection you are analyzing.
+   * @param filters Filters are used to narrow down the events used in an analysis request
+   *   based on event property values. See [[https://keen.io/docs/data-analysis/filters/ Filters]].
+   * @param timeframe A Timeframe specifies the events to use for analysis based on a window
+   *   of time. If no timeframe is specified, all events will be counted. See
+   *   [[https://keen.io/docs/data-analysis/timeframe/ Timeframes]].
+   * @param email Email address to notify when asynchronous extraction is ready for download.
+   * @param latest An integer containing the number of most recent events to extract.
+   * @param propertyNames An array of strings containing properties you wish to extract.
+   *   If this parameter is omitted, all properties will be returned.
+   *
+   * @see [[https://keen.io/docs/api/#extractions Extractions API Reference]]
+   * @todo Should accept timezone parameter: [[https://github.com/keenlabs/KeenClient-Scala/issues/37]]
    */
   def extraction(
     collection: String,
     filters: Option[String] = None,
     timeframe: Option[String] = None,
     email: Option[String] = None,
-    latest: Option[String] = None,
-    propertyNames: Option[String] = None
+    latest: Option[String] = None, // TODO: Integer
+    propertyNames: Option[String] = None // TODO: List of Strings
   ): Future[Response] =
 
     doQuery(
@@ -251,7 +269,7 @@ trait Reader extends AccessLevel {
    * @param timezone Modifies the timeframe filters for Relative Timeframes to match a specific timezone.
    * @param groupBy The group_by parameter specifies the name of a property by which you would like to group the results. Using this parameter changes the response format. See [[https://keen.io/docs/data-analysis/group-by/ Group By]].
    *
-   * @see [[https://keen.io/docs/api/reference/#maximum-resource Maximum Resource]]
+   * @see [[https://keen.io/docs/api/#maximum Maximum API Reference]]
    */
   def maximum(
     collection: String,
@@ -283,7 +301,7 @@ trait Reader extends AccessLevel {
    * @param timezone Modifies the timeframe filters for Relative Timeframes to match a specific timezone.
    * @param groupBy The group_by parameter specifies the name of a property by which you would like to group the results. Using this parameter changes the response format. See [[https://keen.io/docs/data-analysis/group-by/ Group By]].
    *
-   * @see [[https://keen.io/docs/api/reference/#minimum-resource Minimum Resource]]
+   * @see [[https://keen.io/docs/api/#minimum Minimum API Reference]]
    */
   def minimum(
     collection: String,
@@ -314,7 +332,7 @@ trait Reader extends AccessLevel {
    * @param timezone Modifies the timeframe filters for Relative Timeframes to match a specific timezone.
    * @param groupBy The group_by parameter specifies the name of a property by which you would like to group the results. Using this parameter changes the response format. See [[https://keen.io/docs/data-analysis/group-by/ Group By]].
    *
-   * @see [[https://keen.io/docs/api/reference/#select-unique-resource Select Unique Resource]]
+   * @see [[https://keen.io/docs/api/#select-unique Select Unique API Reference]]
    */
   def selectUnique(
     collection: String,
@@ -346,7 +364,7 @@ trait Reader extends AccessLevel {
    * @param timezone Modifies the timeframe filters for Relative Timeframes to match a specific timezone.
    * @param groupBy The group_by parameter specifies the name of a property by which you would like to group the results. Using this parameter changes the response format. See [[https://keen.io/docs/data-analysis/group-by/ Group By]].
    *
-   * @see [[https://keen.io/docs/api/reference/#sum-resource Sum Resource]]
+   * @see [[https://keen.io/docs/api/#sum Sum API Reference]]
    */
   def sum(
     collection: String,
@@ -394,6 +412,7 @@ trait Reader extends AccessLevel {
       "property_names" -> propertyNames
     )
 
+    // TODO: Prefer POST when available, avoids URL encoding concerns, etc.
     doRequest(path = path, method = "GET", key = readKey, params = params)
   }
 }
@@ -430,7 +449,7 @@ trait Writer extends AccessLevel {
    * @param collection The collection to which the event will be added.
    * @param event The event
    *
-   * @see [[https://keen.io/docs/api/reference/#event-collection-resource Event Collection Resource]]
+   * @see [[https://keen.io/docs/api/#record-a-single-event Record a single event API Reference]]
    */
   def addEvent(collection: String, event: String): Future[Response] = {
     val path = Seq(version, "projects", projectId, "events", collection).mkString("/")
@@ -441,7 +460,7 @@ trait Writer extends AccessLevel {
    * Publish multiple events.
    *
    * @param events The events to add to the project.
-   * @see [[https://keen.io/docs/api/reference/#event-resource Event Resource]]
+   * @see [[https://keen.io/docs/api/#record-multiple-events Record multiple events API Reference]]
    */
   def addEvents(events: String): Future[Response] = {
     val path = Seq(version, "projects", projectId, "events").mkString("/")
@@ -491,7 +510,7 @@ trait Master extends Reader with Writer {
    * for collections under 10k events.
    *
    * @param collection The name of the collection.
-   * @see [[https://keen.io/docs/api/reference/#event-collection-resource Event Collection Resource]]
+   * @see [[https://keen.io/docs/api/#delete-a-collection Delete a Collection API Reference]]
    */
   def deleteCollection(collection: String): Future[Response] = {
     val path = Seq(version, "projects", projectId, "events", collection).mkString("/")
@@ -500,7 +519,7 @@ trait Master extends Reader with Writer {
 
   /**
    * Removes a property and deletes all values stored with that property name.
-   * @see [[https://keen.io/docs/api/reference/#property-resource Property Resource]]
+   * @see [[https://keen.io/docs/api/#delete-a-property Delete a Property API Reference]]
    */
   def deleteProperty(collection: String, name: String): Future[Response] = {
     val path = Seq(version, "projects", projectId, "events", collection, "properties", name).mkString("/")
@@ -509,7 +528,8 @@ trait Master extends Reader with Writer {
 
   /**
    * Returns schema information for all the event collections in this project.
-   * @see [[https://keen.io/docs/api/reference/#event-resource Event Resource]]
+   * @see [[https://keen.io/docs/api/#inspect-all-collections Inspect all collections API Reference]]
+   * @todo This only requires a read key, move to Reader
    */
   def getEvents: Future[Response] = {
     val path = Seq(version, "projects", projectId, "events").mkString("/")
@@ -521,7 +541,8 @@ trait Master extends Reader with Writer {
    * properties and their type. It also returns links to sub-resources.
    *
    * @param collection The name of the collection.
-   * @see [[https://keen.io/docs/api/reference/#event-collection-resource Event Collection Resource]]
+   * @see [[https://keen.io/docs/api/#inspect-a-single-collection Inspect a single collection API Reference]]
+   * @todo This only requires a read key, move to Reader
    */
   def getCollection(collection: String): Future[Response] = {
     val path = Seq(version, "projects", projectId, "events", collection).mkString("/")
@@ -531,7 +552,7 @@ trait Master extends Reader with Writer {
   /**
    * Returns the projects accessible to the API user, as well as links to project sub-resources for
    * discovery.
-   * @see [[https://keen.io/docs/api/reference/#projects-resource Projects Resource]]
+   * @see [[https://keen.io/docs/api/#inspect-all-projects Inspect all projects API Reference]]
    */
   def getProjects: Future[Response] = {
     val path = Seq(version, "projects").mkString("/")
@@ -540,7 +561,7 @@ trait Master extends Reader with Writer {
 
   /**
    * Returns detailed information about the specific project, as well as links to related resources.
-   * @see [[https://keen.io/docs/api/reference/#project-row-resource Project Row Resource]]
+   * @see [[https://keen.io/docs/api/#inspect-a-single-project Inspect a single project API Reference]]
    */
   def getProject: Future[Response] = {
     val path = Seq(version, "projects", projectId).mkString("/")
@@ -549,7 +570,8 @@ trait Master extends Reader with Writer {
 
   /**
    * Returns the property name, type, and a link to sub-resources.
-   * @see [[https://keen.io/docs/api/reference/#property-resource Property Resource]]
+   * @see [[https://keen.io/docs/api/#inspect-a-single-property Inspect a single property API Reference]]
+   * @todo This only requires a read key, move to Reader
    */
   def getProperty(collection: String, name: String): Future[Response] = {
     val path = Seq(version, "projects", projectId, "events", collection, "properties", name).mkString("/")
@@ -557,8 +579,8 @@ trait Master extends Reader with Writer {
   }
 
   /**
-   * Returns the list of available queries and links to them.
-   * @see [[https://keen.io/docs/api/reference/#queries-resource Queries Resource]]
+   * Returns the list of available query resources as paths to their endpoints.
+   * @see [[https://keen.io/docs/api/#query-availability Query Availability API Reference]]
    */
   def getQueries: Future[Response] = {
     val path = Seq(version, "projects", projectId, "queries").mkString("/")

--- a/src/main/scala/io/keen/client/scala/EventStore.scala
+++ b/src/main/scala/io/keen/client/scala/EventStore.scala
@@ -4,17 +4,69 @@ import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 
 /**
- * Abstraction for implementing custom event stores.
+ * An EventStore is an abstract store for events, intended primarily as a write
+ * cache for events to be flushed in batches, such as by a [[BatchWriterClient]].
+ *
+ * The documentation refers to "handles", which you can think of simply as cache
+ * keys or map keys in common parlance. The parameter naming is historical.
+ *
+ * @todo I'd like to change parameter names to `key` before 1.0.
+ * @todo The handle/key type could be generic instead of `Long`.
+ * @todo The data structure should be generalized from `TrieMap` & `ListBuffer`
  */
 trait EventStore {
+  /**
+   * Sets a maximum number of events that should be stored per-collection.
+   * Eviction strategy may vary by implementation.
+   *
+   * @todo This could be moved to RamEventStore instead of being a formal part
+   *   of the interface.
+   */
   var maxEventsPerCollection: Integer = 10000
+
+  /**
+   * The number of events currently in the store.
+   *
+   * @todo This should be an accessor method with private field, not public var.
+   * @todo Long? The implementation in RamEventStore uses Longs for key/handle/ID, so…
+   */
   var size: Integer = 0
 
+  /**
+   * Stores an event in the store.
+   *
+   * @param projectId       The ID of the project to which the collection belongs.
+   * @param eventCollection The collection to which the event will be added.
+   * @param event           The event.
+   *
+   * @return A handle which can be used to retrieve or remove the event from the
+   *   store (a cache key).
+   */
   def store(projectId: String, eventCollection: String, event: String): Long
 
+  /**
+   * Retrieves an event from the store.
+   *
+   * @param handle The cache key of the event to retrieve.
+   * @return       The event string.
+   *
+   * @todo Should return an Option[String] in Scala land.
+   * @todo Non-Option instance apply() version could be added for idiomatic Scala.
+   */
   def get(handle: Long): String
 
+  /**
+   * Removes an event from the store.
+   *
+   * @param handle The handle of the event.
+   */
   def remove(handle: Long): Unit
 
+  /**
+   * Retrieves all handles for a specific project from the store.
+   *
+   * @param projectId The ID of the project.
+   * @return          A map of collection names to their event handles.
+   */
   def getHandles(projectId: String): TrieMap[String, ListBuffer[Long]]
 }

--- a/src/main/scala/io/keen/client/scala/HttpAdapter.scala
+++ b/src/main/scala/io/keen/client/scala/HttpAdapter.scala
@@ -4,11 +4,25 @@ import scala.concurrent.Future
 
 case class Response(statusCode: Int, body: String)
 
+/**
+ * Expresses a dependency on an [[HttpAdapter]], which an implementor or library
+ * user must provide.
+ */
 trait HttpAdapterComponent {
   val httpAdapter: HttpAdapter
 }
 
+/**
+ * A basic HTTP client abstraction. This interface allows pluggable use of new
+ * HTTP client libraries of your choice for the Keen [[Client]].
+ */
 trait HttpAdapter {
+  /**
+   * Perform an HTTP request.
+   *
+   * @todo Not even documenting the params yet because I'm in the midst of
+   *   refactoring the hell out of this :-)
+   */
   def doRequest(
     scheme: String,
     authority: String,
@@ -19,5 +33,6 @@ trait HttpAdapter {
     params: Map[String, Option[String]] = Map.empty
   ): Future[Response]
 
+  /** Shuts down HTTP client resources. */
   def shutdown(): Unit
 }

--- a/src/main/scala/io/keen/client/scala/HttpAdapterDispatch.scala
+++ b/src/main/scala/io/keen/client/scala/HttpAdapterDispatch.scala
@@ -6,8 +6,11 @@ import dispatch._
 import scala.concurrent.Future
 
 /**
- * Extension of HttpAdapter that uses Dispatch rather than Spray+akka
- * Helps avoid dependency conflicts in use cases such as Spark
+ * An [[HttpAdapter]] built on the [[http://dispatch.databinder.net/ Dispatch]]
+ * HTTP client library.
+ *
+ * @param httpTimeoutSeconds Sets a timeout for HTTP requests, in seconds.
+ * @todo Move the timeout constructor param to config; it's not used here!
  */
 class HttpAdapterDispatch(httpTimeoutSeconds: Int = 10) extends HttpAdapter {
   val http = new Http
@@ -54,5 +57,6 @@ class HttpAdapterDispatch(httpTimeoutSeconds: Int = 10) extends HttpAdapter {
 
   def shutdown() = http.shutdown()
 
+  // TODO: This is dubious...
   override protected def finalize() = shutdown()
 }

--- a/src/main/scala/io/keen/client/scala/HttpAdapterSpray.scala
+++ b/src/main/scala/io/keen/client/scala/HttpAdapterSpray.scala
@@ -14,6 +14,13 @@ import spray.http.Uri._
 import spray.http.HttpHeaders.RawHeader
 import spray.httpx.RequestBuilding._
 
+/**
+ * An [[HttpAdapter]] built on HTTP client support of the [[http://spray.io/
+ * Spray HTTP toolkit]].
+ *
+ * @param httpTimeoutSeconds Sets a timeout for HTTP requests, in seconds.
+ * @todo Move the timeout constructor param to config
+ */
 class HttpAdapterSpray(httpTimeoutSeconds: Int = 10)(implicit val actorSystem: ActorSystem = ActorSystem("keen-client"))
     extends HttpAdapter with Logging {
 
@@ -73,6 +80,12 @@ class HttpAdapterSpray(httpTimeoutSeconds: Int = 10)(implicit val actorSystem: A
       })
   }
 
+  /**
+   * @inheritdoc
+   *
+   * Disconnects any remaining connections. Both idle and active. If you are accessing
+   * Keen through a proxy that keeps connections alive this is useful.
+   */
   def shutdown() = {
     (IO(Http) ? Http.CloseAll) onComplete {
       // When this completes we will shutdown the actor system if it wasn't

--- a/src/main/scala/io/keen/client/scala/HttpAdapterSpray.scala
+++ b/src/main/scala/io/keen/client/scala/HttpAdapterSpray.scala
@@ -18,8 +18,30 @@ import spray.httpx.RequestBuilding._
  * An [[HttpAdapter]] built on HTTP client support of the [[http://spray.io/
  * Spray HTTP toolkit]].
  *
+ * == Akka and Actor Systems ==
+ *
+ * Spray is built upon $AkkaIO and uses an Akka $ActorSystem to handle HTTP I/O.
+ * By default, `HttpAdapterSpray` creates an `ActorSystem` for its own use so
+ * that it works out of the box. If you are using it within an Akka application,
+ * however, it is possible to specify the `ActorSystem` within which it will run
+ * using an implicit parameter.
+ *
+ * @example Using a custom $ActorSystem
+ * {{{
+ * val adapter = new HttpAdapterSpray()(ActorSystem("myapp-system"))
+ * }}}
+ *
+ * @example Using a custom $ActorSystem, implicitly for a scope
+ * {{{
+ * implicit val system = ActorSystem("myapp-system")
+ * val adapter = new HttpAdapterSpray
+ * }}}
+ *
  * @param httpTimeoutSeconds Sets a timeout for HTTP requests, in seconds.
  * @todo Move the timeout constructor param to config
+ *
+ * @define AkkaIO [[http://doc.akka.io/docs/akka/2.3.14/scala/io.html Akka I/O]]
+ * @define ActorSystem [[akka.actor.ActorSystem ActorSystem]]
  */
 class HttpAdapterSpray(httpTimeoutSeconds: Int = 10)(implicit val actorSystem: ActorSystem = ActorSystem("keen-client"))
     extends HttpAdapter with Logging {
@@ -85,6 +107,9 @@ class HttpAdapterSpray(httpTimeoutSeconds: Int = 10)(implicit val actorSystem: A
    *
    * Disconnects any remaining connections. Both idle and active. If you are accessing
    * Keen through a proxy that keeps connections alive this is useful.
+   *
+   * If [[HttpAdapterSpray]]'s default $ActorSystem is in use, it will be shut
+   * down; if a custom `ActorSystem` has been supplied, it will not.
    */
   def shutdown() = {
     (IO(Http) ? Http.CloseAll) onComplete {

--- a/src/main/scala/io/keen/client/scala/Settings.scala
+++ b/src/main/scala/io/keen/client/scala/Settings.scala
@@ -5,12 +5,13 @@ import scala.concurrent.duration.FiniteDuration
 import com.typesafe.config._
 
 /**
- * Configuration settings for Keen Client.
+ * Configuration settings for Keen IO [[Client]].
  *
- * At construction the given `Config` parsed from config files, properties, etc.
- * is validated to ensure that all required keys are present.
+ * Settings can be parsed from config files, properties, environment variables, etc.
+ * as supported by [[https://github.com/typesafehub/config Typesafe Config]].
  *
- * @constructor Creates a new Settings instance.
+ * @constructor Creates a new Settings instance, validating that all required
+ *   keys are present in the given [[com.typesafe.config.Config]].
  *
  * @param config A Typesafe `Config` instance containing at least the required
  *   settings under the "keen" path reflected in the reference file.
@@ -19,29 +20,59 @@ import com.typesafe.config._
  * @throws ConfigException.WrongType if a given configuration value is not of
  *   the required or sensibly coercible type.
  *
- * @todo A helpful toString could be useful here, but should maybe sanitize keys
- *   from accidental logging through exceptions reports, etc.?
+ * @groupdesc Keys [[https://keen.io/docs/api/#api-keys API Keys]]
+ * @groupdesc Batch Settings for batch write functionality, such as implemented
+ *   in [[BatchWriterClient]].
  */
 class Settings(config: Config) {
   // Fail fast if any required settings are missing.
   private val validationReference = ConfigFactory.defaultReference.withoutPath("keen.optional")
   config.checkValid(validationReference, "keen")
 
+  // format: OFF
+
+  /** Keen IO project ID that clients will operate on by default.
+    * From configuration key `keen.project-id`. */
   val projectId: String = config.getString("keen.project-id")
 
   val environment: Option[String] = config.getOptionalString("keen.optional.environment")
 
-  // format: OFF
-
+  /** @group Keys */
   val masterKey: Option[String] = config.getOptionalString("keen.optional.master-key")
+  /** @group Keys */
   val readKey: Option[String]   = config.getOptionalString("keen.optional.read-key")
+  /** @group Keys */
   val writeKey: Option[String]  = config.getOptionalString("keen.optional.write-key")
 
-  // Batched write settings
+  // TODO: These batch field names could use some kind of namespacing
+
+  /** The number of events sent in a single API call when flushing batches.
+    * From configuration key `keen.queue.batch.size`.
+    * @group Batch */
   val batchSize: Integer                   = config.getInt("keen.queue.batch.size")
+
+  /** Timeout for each bulk write API call when flushing batches.
+    * From configuration key `keen.queue.batch.timeout`.
+    * @group Batch */
   val batchTimeout: FiniteDuration         = config.getFiniteDuration("keen.queue.batch.timeout")
+
+  /** Default queue bound to limit events stored in a write cache for batched writes.
+    * From configuration key `keen.queue.queue.max-events-per-collection`.
+    * @group Batch */
   val maxEventsPerCollection: Integer      = config.getInt("keen.queue.max-events-per-collection")
+
+  /** Threshold of queued events at which flush of batches is triggered.
+    * From configuration key `keen.queue.send-interval.events`.
+    * @group Batch */
   val sendIntervalEvents: Integer          = config.getInt("keen.queue.send-interval.events")
+
+  /** Time interval at which batches of queued event writes are scheduled to be flushed.
+    * From configuration key `keen.queue.send-interval.duration`.
+    * @group Batch */
   val sendIntervalDuration: FiniteDuration = config.getFiniteDuration("keen.queue.send-interval.duration")
+
+  /** Duration for which client will wait for scheduled batch flushes to complete when shutting down.
+    * From configuration key `keen.queue.shutdown-delay`.
+    * @group Batch */
   val shutdownDelay: FiniteDuration        = config.getFiniteDuration("keen.queue.shutdown-delay")
 }

--- a/src/main/scala/io/keen/client/scala/package.scala
+++ b/src/main/scala/io/keen/client/scala/package.scala
@@ -4,6 +4,12 @@ import concurrent.duration.{ FiniteDuration, MILLISECONDS }
 
 import com.typesafe.config.Config
 
+/**
+ * Package implementing an asynchronous, idiomatic Scala client for the
+ * [[https://keen.io/docs/ Keen IO]] API.
+ *
+ * @see [[https://github.com/keenlabs/KeenClient-Scala The project home on GitHub]]
+ */
 package object scala {
   /**
    * Enrichment for Typesafe Config to wrap some optional settings in Option, or

--- a/src/site-preprocess/index.html
+++ b/src/site-preprocess/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Project Documentation</title>
+    <script>
+      <!--
+      function doRedirect() {
+        window.location.replace("api/@VERSION@/io/keen/client/scala/package.html");
+      }
+
+      doRedirect();
+      //-->
+    </script>
+  </head>
+
+  <body>
+    <a href="api/@VERSION@/io/keen/client/scala/package.html">Go to the project documentation</a>
+  </body>
+</html>


### PR DESCRIPTION
This branch contains no functional changes, so I `[ci skip]`ed it—you can trust me that the SBT configuration works, or try it out yourself :smile: 

### What this does ###

- Adds a lot of absent Scaladoc, including important types like `Client` and `HttpAdapter`.
- Sets up generating versioned Scaladoc with [sbt-site][] (**note**: uses the 1.0.0-RC3 version of the plugin, so see [that README][1] for reference).
- Sets up publishing the Scaladoc to <http://keenlabs.github.io/KeenClient-Scala/> with GitHub Pages, via [sbt-ghpages]. [Here's a test version][2] on my fork.
- Wires links to source code in the Scaladoc to the matching version on GitHub, using `master` if it's a `SNAPSHOT`.

Adding a lot of documentation basically amounted to a close-reading of the code, and I added a lot of todos along the way… That might be noisy but my goal would be for those to be eliminated by 1.0 or at worst moved out of documentation comments. I welcome thoughts on any of those todos inline.

Scaladoc does pretty smart inheritance of documentation from parent classes/traits automatically, with `@inheritdoc` only needed if you wish to append to a parent's doc. So, I moved some documentation to parents like `EventStore` so implementors can understand how they're supposed to work.

### Caveats ###

One little piece of the story is unfortunately broken currently: publishing multiple versions of the API docs to GitHub Pages. `sbt-site` correctly builds into versioned paths like `/api/0.6.0/`, but `sbt-ghpages` [clobbers all the content in the `gh-pages` branch][3] every time you publish, leaving only the most recent. I consider this a bug, the documentation of the task specifically says it shouldn't do that. I'm going to try to submit a pull request to change it, but the project has been inactive so it might take awhile.

This doesn't really diminish the usefulness of everything done here so far, it just means that unfortunately people may stumble across rotted links to docs for earlier versions until this gets resolved. Once there's a fix we'll just need to update `sbt-ghpages` and everything should keep working, without the loss of doc versions from then on.

### Initializing the project's GitHub Pages ###

[Ignore the `sbt-ghpages` instructions][4] for creating the `gh-pages` branch—they're prone to potentially dangerous error. Here is what I did to test on my fork, using [GitHub's official documentation][5] except with an empty commit to establish the branch:

```
# Use a fresh clone as advised
$ cd /tmp
$ git clone git@github.com:keenlabs/KeenClient-Scala.git
$ cd KeenClient-Scala

# Create branch with no history or content
$ git checkout --orphan gh-pages
$ git rm -rf .

# Establish the branch existence
$ git commit --allow-empty -m "Initialize gh-pages branch"
$ git push origin gh-pages

# Go back to a "real" branch, or better yet just nuke the /tmp clone now
$ git checkout master
```

Create and push the branch before trying to run `sbt ghpagesPushSite`—under the hood it actually clones a sandbox copy of the repo beneath `~/.sbt/ghpages`, and it expects the branch to already exist so it can check it out. The documentation doesn't cover these subtleties very well, but the sandbox approach is nice since it avoids potentially bungling up things in your working copy when it's automating the `gh-pages` branch dance.

Remember that we still have `version` at `0.6.0` in `build.sbt` currently, so you might want to change that to an `0.7.0-SNAPSHOT` or something before publishing docs, since there have been changes since the last release.

[sbt-site]: https://github.com/sbt/sbt-site
[sbt-ghpages]: https://github.com/sbt/sbt-ghpages
[1]: https://github.com/sbt/sbt-site/blob/release/1.0.0-RC3/README.md
[2]: http://ches.github.io/KeenClient-Scala/
[3]: https://github.com/sbt/sbt-ghpages/issues/10
[4]: https://github.com/sbt/sbt-ghpages/issues/15
[5]: https://help.github.com/articles/creating-project-pages-manually/