### PR TITLE
Test coverage and reporting it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ jdk:
   - oraclejdk7
   - openjdk7
 
+script:
+  - sbt clean coverage test
+
+after_success:
+  - sbt coverageReport coveralls
+
 addons:
   # Fix OpenJDK builds
   # https://github.com/travis-ci/travis-ci/issues/5227

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # KeenClient-Scala
 
 [![Build Status]](https://travis-ci.org/keenlabs/KeenClient-Scala)
+[![Coverage Status]](https://coveralls.io/github/keenlabs/KeenClient-Scala?branch=master)
 [![Maven Central Badge]](https://maven-badges.herokuapp.com/maven-central/io.keen/keenclient-scala_2.11)
 [![Scaladoc Badge]](https://keenlabs.github.io/KeenClient-Scala/)
 
@@ -245,6 +246,7 @@ that you didn't expect!**
 
 
 [Build Status]: https://travis-ci.org/keenlabs/KeenClient-Scala.svg?branch=master
+[Coverage Status]: https://coveralls.io/repos/github/keenlabs/KeenClient-Scala/badge.svg?branch=master
 [Maven Central Badge]: https://maven-badges.herokuapp.com/maven-central/io.keen/keenclient-scala_2.11/badge.svg
 [Scaladoc Badge]: https://img.shields.io/badge/scaladoc-latest-lightgrey.svg
 [Keen IO]: http://keen.io/

--- a/build.sbt
+++ b/build.sbt
@@ -48,13 +48,6 @@ enablePlugins(GitBranchPrompt)
 Defaults.itSettings
 configs(IntegrationTest)
 
-// Fail builds if pull requests don't maintain test coverage. Bump this up as
-// coverage improves. Coverage is better if we include integration tests, but we
-// need to separate true end-to-end tests that require account credentials since
-// these are troublesome to run on CI.
-coverageMinimum := 60
-coverageFailOnMinimum := true
-
 /**
  * Scaladoc Generation
  *

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,13 @@ enablePlugins(GitBranchPrompt)
 Defaults.itSettings
 configs(IntegrationTest)
 
+// Fail builds if pull requests don't maintain test coverage. Bump this up as
+// coverage improves. Coverage is better if we include integration tests, but we
+// need to separate true end-to-end tests that require account credentials since
+// these are troublesome to run on CI.
+coverageMinimum := 60
+coverageFailOnMinimum := true
+
 /**
  * Scaladoc Generation
  *

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,8 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0-RC3")
 

--- a/src/it/scala/ClientIntegrationSpec.scala
+++ b/src/it/scala/ClientIntegrationSpec.scala
@@ -5,9 +5,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 
-class ClientIntegrationSpec extends Specification with NoTimeConversions {
+class ClientIntegrationSpec extends Specification {
   // Timeout used for most future awaits, etc. ScalaTest and Akka TestKit both
   // feature scalable time dilation for testing on CI servers that might be
   // slow--see IntegrationPatience in ScalaTest, not sure if specs2 has similar...

--- a/src/test/scala/BatchWriterClientSpec.scala
+++ b/src/test/scala/BatchWriterClientSpec.scala
@@ -110,7 +110,7 @@ class BatchWriterClientSpec extends ClientSpecification {
       // TODO: This is basically an integration test, and slow. We could test this
       // with a mock that verifies sendQueuedEvents is called after shorter duration.
       // It's brittle too, use specs2 timeFactor if needed.
-      Thread.sleep((client.settings.sendIntervalDuration + 100.millis).toMillis)
+      Thread.sleep((client.settings.sendIntervalDuration + 2.seconds).toMillis)
 
       // validate that the store is now empty as a result of sendQueuedEvents being automatically
       // triggered with the queueing of the 100th event


### PR DESCRIPTION
This is the last of my project quality meta proposals for awhile, I think…

This adds [sbt-scoverage] for producing test coverage reports, and publishes them to [Codecov][] (if Keen wants to enable that). Codecov seems like a nice new alternative to Coveralls so I thought I'd try it, but if you would prefer to use Coveralls or something else that supports Scala or none of these, I will adjust this PR.

You can generate a local static HTML report under `target/` with:

```sh
$ sbt clean coverage test coverageReport
```

or in the interactive sbt shell with its multi-task syntax:

    sbt> ; clean ; coverage ; test ; coverageReport

(Run `coverageOff` after that, because enabling coverage is sticky in interactive mode).

Add `it:test` in the sequence after `test` to have integration test coverage combined in the report, if you have credentials configured for a dummy Keen account.

The added `.travis.yml` config pushes the XML coverage output to Codecov which can render HTML for browsing, add a check to GitHub commits/PRs for maintaining coverage, etc.

Here's [an example of how it should look][1], but admittedly I haven't gotten a proper report yet because the build is still unstable :disappointed:  You can see how it will appear, just that the coverage percentage and line marking are incomplete.

Speaking of that instability, I kept raising the sleep time on the test that intermittently fails as an attempt at a quick band aid, but even at 2 seconds which is pretty ridiculous I still got intermittent failures. I'll attempt to write that test in a more robust way—or verify the implementation—when time and enthusiasm allows, but I'm trying to leave the batch write code alone for a little while…

This will have minor conflicts with #47, I'll rebase either one as appropriate.

[sbt-scoverage]: https://github.com/scoverage/sbt-scoverage
[Codecov]: https://codecov.io/
[1]: https://codecov.io/github/ches/KeenClient-Scala?branch=coverage