### PR TITLE
Add sbt-release for release automation, set 0.8.0-SNAPSHOT

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,26 +1,63 @@
-# Publishing
+Release Process
+---------------
 
-We host artifacts for this library on Maven Central. [Here are the official docs for that](http://central.sonatype.org/pages/ossrh-guide.html).
+Following is the procedure for publishing new releases. If you're making your first release, see the *Publishing Setup* section below first.
 
-Those are kinda complicated, so you'll need the following to publish to it:
-
-* An account on the Sonatype JIRA
-* If you've never published to the io.keen namespace you'll need to open a ticket to get yourself added to that. [Here's mine](https://issues.sonatype.org/browse/OSSRH-12955).
-* Generate a local GPG key and publish it to a keyserver. I ended up having to export mine ascii armored and uploading it by hand to `keyserver.ubuntu.com`.
-
-# Actual Release Process
-
-* Update `CHANGELOG.md`
-* Update `version` in `build.sbt`
-* Commit, tag, and push
-* Publish the artifacts:
-    * Run `sbt +publishSigned`
+* Ensure `CHANGELOG.md` is up-to-date and you're on `master` with clean git index.
+* Run `sbt release`. You will be prompted for versions, with likely defaults filled.
+* Release the published artifacts for public consumption:
     * Visit [Sonatype](https://oss.sonatype.org/#stagingRepositories) and "Close" the repo
     * Await the above to finish, fix anything that breaks if it breaks
     * Go to Sonatype again and "Release" the repo
     * It should show up on Maven Central at some point after that.
-* Publish new Scaladoc API documentation:
 
-        $ sbt ghpagesPushSite
+It's possible to run `sbt release` in a non-interactive manner, but you probably want to pause to think about the SemVer implications of the release and verify that what automation suggests is the appropriate choice.
 
-  If you're feeling prudent, you can run `sbt previewSite` first to take a look.
+Metadata for our artifacts and other nexus details are set in the `publishing.sbt` file.
+
+### The sbt release Magic ###
+
+Here is what `sbt release` does, in a nutshell:
+
+1. Makes sure git is clean and no `SNAPSHOT` dependencies are declared in the project.
+1. Prompts for the number of the version to be released, and the subsequent development version to set after the release.
+1. Runs unit tests, aborting release if there are failures.
+1. Writes the release version to `version.sbt` and commits that.
+1. Tags that release commit.
+1. Publishes the cross-version artifacts to Maven Central.
+1. Writes the next development `SNAPSHOT` version to `version.sbt` and commits that.
+1. Pushes to GitHub.
+1. Publishes Scaladoc to <https://keenlabs.github.io/KeenClient-Scala/>.
+
+This process can be completely customized, see [sbt-release](https://github.com/sbt/sbt-release).
+
+Publishing Setup
+----------------
+
+We host artifacts for this library on Maven Central. [Here are the official docs for that](http://central.sonatype.org/pages/ossrh-guide.html).
+
+**TL;DR** you'll need to do the following to publish releases:
+
+1. Create an account on [the Sonatype JIRA](http://issues.sonatype.org/).
+2. Request publish access for our `io.keen` namespace by commenting on [our project's ticket](https://issues.sonatype.org/browse/OSSRH-12955).
+3. Log in with the same Sonatype account at <http://oss.sonatype.org> and create an access token:
+    - Navigate to your profile
+    - Select user token from the profile settings dropdown
+    - Click access user token
+4. Create a [credentials file] at `~/.ivy2/.credentials` that looks like this, using your username and the token from the previous step:
+
+         realm=Sonatype Nexus Repository Manager
+         host=oss.sonatype.org
+         user=<username>
+         password=<token>
+
+5. Finally, releases must be PGP-signed, so if you have never created a GPG key for your email address and distributed it to keyservers, you should do so now. `sbt-pgp` (already installed in this project) can help:
+
+         $ sbt
+         > set pgpReadOnly := false
+         > pgp-cmd gen-key
+         > pgp-cmd send-key <email addr> hkp://keyserver.ubuntu.com
+
+   See <http://www.scala-sbt.org/sbt-pgp/usage.html> if you need further info.
+
+[credentials file]: http://www.scala-sbt.org/0.13/docs/Publishing.html#Credentials

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,11 @@
-name := "keenclient-scala"
-
+name         := "keenclient-scala"
 organization := "io.keen"
+description  := "Keen IO SDK/client library for Scala"
+homepage     := Some(url("https://github.com/keenlabs/KeenClient-Scala"))
 
-description := "Keen IO SDK/client library for Scala"
-
-homepage := Some(url("https://github.com/keenlabs/KeenClient-Scala"))
-
-version := "0.7.0"
-
-scalaVersion := "2.11.7"
-
+scalaVersion       := "2.11.7"
 crossScalaVersions := Seq("2.10.6", scalaVersion.value)
-
-scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xlint")
+scalacOptions     ++= Seq("-unchecked", "-deprecation", "-feature", "-Xlint")
 
 resolvers ++= Seq(
   "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
@@ -47,6 +40,26 @@ enablePlugins(GitBranchPrompt)
 // SBT support for Maven-style integration tests (src/it)
 Defaults.itSettings
 configs(IntegrationTest)
+
+/**
+ * Release Automation
+ *
+ * Adds the `release` task to do version bumping, artifact publishing, etc.
+ * See PUBLISHING.md for a rundown of how to make releases.
+ */
+releaseCrossBuild    := true
+releaseTagComment    := s"Release ${(version in ThisBuild).value}"
+releaseCommitMessage := s"Set version to ${(version in ThisBuild).value}"
+
+// For pre-1.0. The default of Next is probably better after that.
+releaseVersionBump := sbtrelease.Version.Bump.Minor
+
+// Releases publish signed artifacts. See publishing.sbt for the setup.
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
+
+// Tack on ScalaDoc publishing task (configured below) to end of release process
+import com.typesafe.sbt.SbtGhPages.GhPagesKeys
+releaseProcess += releaseStepTask(GhPagesKeys.pushSite in thisProjectRef.value)
 
 /**
  * Scaladoc Generation
@@ -104,7 +117,9 @@ preprocessVars := Map("VERSION" -> version.value)
 ghpages.settings
 git.remoteRepo := "git@github.com:keenlabs/KeenClient-Scala.git"
 
-// Source Formatting
+/**
+ * Automated source formatting upon compile, for focused code review.
+ */
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import scalariform.formatter.preferences._

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,11 @@
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0-RC3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0")
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.8.0-SNAPSHOT"


### PR DESCRIPTION
Welp, I thought I was through with project-meta contributions for awhile, but I just set up [sbt-release] on another project so I figured I would add it here. KeenClient-Scala has become my open source crib sheet for remembering useful SBT configuration later 😁 

The [release process documentation updated in the changeset][1] is a good description of what this PR does, but in short it basically completely reduces the release process to "update changelog, run `sbt release`".

Frankly, this is more frustrating than helpful until we fix the fragile build, so I'm going to try to do that next and it might be sensible to leave this unmerged until then. I just wanted to push the branch for safe keeping, and here's the PR just to let people know it's in the pipeline.

[sbt-release]: https://github.com/sbt/sbt-release
[1]: https://github.com/ches/KeenClient-Scala/blob/release-automation/PUBLISHING.md